### PR TITLE
Fix automatic hide detail label

### DIFF
--- a/Sources/TextField.swift
+++ b/Sources/TextField.swift
@@ -449,9 +449,10 @@ public class TextField : UITextField {
 		if 0 < text?.utf16.count {
 			showTitleLabel()
 			if !detailLabelHidden {
-				MaterialAnimation.animationDisabled { [unowned self] in
-					self.bottomBorderLayer.backgroundColor = self.detailLabelActiveColor?.CGColor
-				}
+                detailLabelHidden = true
+                MaterialAnimation.animationDisabled { [unowned self] in
+                    self.bottomBorderLayer.backgroundColor = self.titleLabelColor?.CGColor
+                }
 			}
 		} else if 0 == text?.utf16.count {
 			hideTitleLabel()


### PR DESCRIPTION
This pull request fixes the automatic hiding of the detail label upon any text field changes as per material design default behaviour.