### PR TITLE
MaterialDeviceType switch issue

### DIFF
--- a/Sources/MaterialDevice.swift
+++ b/Sources/MaterialDevice.swift
@@ -47,7 +47,7 @@ public struct MaterialDevice {
 			return .iPhone
 		case .TV:
 			return .TV
-		case .Unspecified:
+		default:
 			return .Unspecified
 		}
 	}


### PR DESCRIPTION
XCode build error: Switch must be exhaustive, consider adding a default clause