### PR TITLE
Fixed missing UIKit imports

### DIFF
--- a/Sources/MaterialCollectionViewDataSource.swift
+++ b/Sources/MaterialCollectionViewDataSource.swift
@@ -28,6 +28,8 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+import UIKit
+
 public protocol MaterialCollectionViewDataSource : UICollectionViewDataSource {
 	/**
 	Retrieves the items for the collectionView.

--- a/Sources/MaterialCollectionViewDelegate.swift
+++ b/Sources/MaterialCollectionViewDelegate.swift
@@ -28,6 +28,8 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+import UIKit
+
 public protocol MaterialCollectionViewDelegate : MaterialDelegate, UICollectionViewDelegate {
 	
 }


### PR DESCRIPTION
Added `import UIKit` to both `MaterialCollectionViewDelegate` and `MaterialCollectionViewDataSource` allowing people using the source directly to use in a dynamic framework