### PR TITLE
Fixed Default TextField Colors

### DIFF
--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -298,6 +298,8 @@ public class TextField : UITextField {
 			if nil == lineLayerActiveColor {
 				lineLayerActiveColor = titleLabelActiveColor
 			}
+            
+            tintColor = titleLabelActiveColor
 		}
 	}
 	
@@ -484,9 +486,9 @@ public class TextField : UITextField {
 	public func prepareView() {
 		backgroundColor = MaterialColor.white
 		masksToBounds = false
-		placeholderTextColor = MaterialColor.grey.base
+		placeholderTextColor = MaterialColor.darkText.others
 		font = RobotoFont.regularWithSize(16)
-		textColor = MaterialColor.grey.darken4
+		textColor = MaterialColor.darkText.primary
 		borderStyle = .None
 		prepareClearButton()
 		prepareTitleLabel()
@@ -559,7 +561,7 @@ public class TextField : UITextField {
 		titleLabel.font = RobotoFont.mediumWithSize(12)
 		addSubview(titleLabel)
 		
-		titleLabelColor = MaterialColor.grey.base
+		titleLabelColor = placeholderTextColor
 		titleLabelActiveColor = MaterialColor.blue.accent3
 		
 		if 0 < text?.utf16.count {
@@ -608,9 +610,10 @@ public class TextField : UITextField {
 		let image: UIImage? = MaterialIcon.cm.close
 		clearButton = FlatButton()
 		clearButton.contentEdgeInsets = UIEdgeInsetsZero
-		clearButton.pulseColor = MaterialColor.grey.base
+		clearButton.pulseColor = MaterialColor.black
+        clearButton.pulseOpacity = 0.12
 		clearButton.pulseScale = false
-		clearButton.tintColor = MaterialColor.grey.base
+		clearButton.tintColor = placeholderTextColor
 		clearButton.setImage(image, forState: .Normal)
 		clearButton.setImage(image, forState: .Highlighted)
 		clearButtonAutoHandleEnabled = true


### PR DESCRIPTION
Current TextField default colors are too bold and don't follow Material Design guidelines.

References: 
- [Text and background colors](https://www.google.com/design/spec/style/color.html#color-text-background-colors)
- [Toggle buttons](https://www.google.com/design/spec/components/buttons.html#buttons-toggle-buttons)