### PR TITLE
Fix In-Call status Bar bug

### DIFF
--- a/Sources/iOS/SideNavigationController.swift
+++ b/Sources/iOS/SideNavigationController.swift
@@ -762,6 +762,7 @@ public class SideNavigationController : UIViewController, UIGestureRecognizerDel
 	/// A method that prepares the rootViewController.
 	private func prepareRootViewController() {
 		rootViewController.view.clipsToBounds = true
+        rootViewController.view.frame = view.bounds
 		rootViewController.view.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
 		prepareViewControllerWithinContainer(rootViewController, container: view)
 	}


### PR DESCRIPTION
Hi,

Adding this line of code, resolves a weird bug:

When you open the app after toggling inCall Status Bar, then untoggling the inCall Status Bar, there will be a problem with the status bar and the general frame of the rootViewController.

You can relate with this [stackoverflow question](http://stackoverflow.com/questions/30329362/status-bar-sized-incorrectly-with-a-contained-uinavigationcontroller) that explains better the problem (especially with the screenshots).

The problem doesn't seem to affect the leftView or rightView ! But we should still be aware of that specific case.

Cheers !
 