### PR TITLE
Improved navigationBar widget

### DIFF
--- a/Examples/Programmatic/App/App/AppDelegate.swift
+++ b/Examples/Programmatic/App/App/AppDelegate.swift
@@ -37,6 +37,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	var window: UIWindow?
 	
 	func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .Left
+        
+        UINavigationBar.appearance().titleTextAttributes = [
+            NSFontAttributeName: RobotoFont.regularWithSize(18),
+            NSForegroundColorAttributeName: MaterialColor.white,
+            NSSecondaryFontAttributeName: RobotoFont.regularWithSize(12),
+            NSParagraphStyleAttributeName: paragraphStyle
+        ]
 		
 		let navigationController: AppNavigationController = AppNavigationController(rootViewController: RecipesViewController())
 		

--- a/Examples/Programmatic/App/App/ItemViewController.swift
+++ b/Examples/Programmatic/App/App/ItemViewController.swift
@@ -38,9 +38,6 @@ class ItemViewController: UIViewController {
 	/// ImageCardView to display item.
 	private var imageCardView: ImageCardView!
 	
-	/// NavigationBar title label.
-	private var titleLabel: UILabel!
-	
 	/// NavigationBar detail label.
 	private var detailLabel: UILabel!
 	
@@ -66,11 +63,12 @@ class ItemViewController: UIViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		prepareView()
-		prepareTitleLabel()
 		prepareShareButton()
 		prepareNavigationItem()
 		prepareScrollView()
 		prepareImageCardView()
+        
+        self.title = "Item"
 	}
 	
 	override func viewWillAppear(animated: Bool) {
@@ -101,22 +99,6 @@ class ItemViewController: UIViewController {
 		automaticallyAdjustsScrollViewInsets = false
 	}
 	
-	/// Prepares the titleLabel.
-	private func prepareTitleLabel() {
-		titleLabel = UILabel()
-		titleLabel.text = "Item"
-		titleLabel.textAlignment = .Left
-		titleLabel.textColor = MaterialColor.white
-	}
-	
-	/// Prepares the detailLabel.
-	private func prepareDetailLabel() {
-		detailLabel = UILabel()
-		detailLabel.text = "January 22, 2016"
-		detailLabel.textAlignment = .Left
-		detailLabel.textColor = MaterialColor.white
-	}
-	
 	/// Prepares the shareButton.
 	private func prepareShareButton() {
 		let image: UIImage? = MaterialIcon.cm.share
@@ -129,8 +111,6 @@ class ItemViewController: UIViewController {
 	
 	/// Prepares the navigationItem.
 	private func prepareNavigationItem() {
-		navigationItem.titleLabel = titleLabel
-		navigationItem.detailLabel = detailLabel
 		navigationItem.rightControls = [shareButton]
 	}
 	

--- a/Examples/Programmatic/App/App/RecipesViewController.swift
+++ b/Examples/Programmatic/App/App/RecipesViewController.swift
@@ -35,9 +35,6 @@ class RecipesViewController: UIViewController {
 	/// A list of all the data source items.
 	private var dataSourceItems: Array<MaterialDataSourceItem>!
 	
-	/// NavigationBar title label.
-	private var titleLabel: UILabel!
-	
 	/// NavigationBar menu button.
 	private var menuButton: FlatButton!
 	
@@ -54,7 +51,6 @@ class RecipesViewController: UIViewController {
 		super.viewDidLoad()
 		prepareView()
 		prepareItems()
-		prepareTitleLabel()
 		prepareMenuButton()
 		prepareSwitchControl()
 		prepareSearchButton()
@@ -218,14 +214,6 @@ class RecipesViewController: UIViewController {
 		view.backgroundColor = MaterialColor.white
 	}
 	
-	/// Prepares the titleLabel.
-	private func prepareTitleLabel() {
-		titleLabel = UILabel()
-		titleLabel.text = "Recipes"
-		titleLabel.textAlignment = .Left
-		titleLabel.textColor = MaterialColor.white
-	}
-	
 	/// Prepares the menuButton.
 	private func prepareMenuButton() {
 		let image: UIImage? = MaterialIcon.cm.menu
@@ -255,9 +243,10 @@ class RecipesViewController: UIViewController {
 	
 	/// Prepares the navigationItem.
 	private func prepareNavigationItem() {
-		navigationItem.titleLabel = titleLabel
 		navigationItem.leftControls = [menuButton]
-		navigationItem.rightControls = [switchControl, searchButton]
+        navigationItem.rightControls = [switchControl, searchButton]
+        self.title = "Recipes"
+        self.navigationItem.detail = "All Recipes"
 	}
 	
 	/// Prepares the tableView.
@@ -336,6 +325,8 @@ extension RecipesViewController: UITableViewDelegate {
 	}
 	
 	func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-		navigationController?.pushViewController(ItemViewController(dataSource: dataSourceItems[indexPath.row]), animated: true)
+        let viewController = ItemViewController(dataSource: dataSourceItems[indexPath.row])
+//		navigationController?.pushViewController(viewController, animated: true)
+        presentViewController(AppNavigationController(rootViewController: viewController), animated: true, completion: nil)
 	}
 }

--- a/Examples/Programmatic/App/App/RecipesViewController.swift
+++ b/Examples/Programmatic/App/App/RecipesViewController.swift
@@ -326,7 +326,7 @@ extension RecipesViewController: UITableViewDelegate {
 	
 	func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let viewController = ItemViewController(dataSource: dataSourceItems[indexPath.row])
-//		navigationController?.pushViewController(viewController, animated: true)
-        presentViewController(AppNavigationController(rootViewController: viewController), animated: true, completion: nil)
+		navigationController?.pushViewController(viewController, animated: true)
+//        presentViewController(AppNavigationController(rootViewController: viewController), animated: true, completion: nil)
 	}
 }

--- a/Examples/Programmatic/NavigationBar/NavigationBar/ViewController.swift
+++ b/Examples/Programmatic/NavigationBar/NavigationBar/ViewController.swift
@@ -53,8 +53,6 @@ class ViewController: UIViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		prepareView()
-		prepareTitleLabel()
-		prepareDetailLabel()
 		prepareMenuButton()
 		prepareSwitchControl()
 		prepareSearchButton()
@@ -69,22 +67,6 @@ class ViewController: UIViewController {
 	/// General preparation statements.
 	private func prepareView() {
 		view.backgroundColor = MaterialColor.white
-	}
-	
-	/// Prepares the titleLabel.
-	private func prepareTitleLabel() {
-		titleLabel = UILabel()
-		titleLabel.text = "Recipes"
-		titleLabel.textAlignment = .Left
-		titleLabel.textColor = MaterialColor.white
-	}
-	
-	/// Prepares the titleLabel.
-	private func prepareDetailLabel() {
-		detailLabel = UILabel()
-		detailLabel.text = "8 Items"
-		detailLabel.textAlignment = .Left
-		detailLabel.textColor = MaterialColor.white
 	}
 	
 	/// Prepares the menuButton.
@@ -114,6 +96,13 @@ class ViewController: UIViewController {
 	
 	/// Prepare navigationBar.
 	private func prepareNavigationBar() {
+        
+        UINavigationBar.appearance().titleTextAttributes = [
+            NSFontAttributeName: RobotoFont.thinWithSize(20),
+            NSSecondaryFontAttributeName: RobotoFont.boldWithSize(13),
+            NSForegroundColorAttributeName: MaterialColor.white
+        ]
+        
 		navigationBar = NavigationBar()
 		navigationBar.statusBarStyle = .LightContent
 		navigationBar.tintColor = MaterialColor.white
@@ -122,10 +111,10 @@ class ViewController: UIViewController {
 		view.addSubview(navigationBar)
 		
 		let item: UINavigationItem = UINavigationItem()
-		item.titleLabel = titleLabel
-		item.detailLabel = detailLabel
 		item.leftControls = [menuButton]
 		item.rightControls = [switchControl, searchButton]
+        item.title = "Recipes"
+        item.detail = "8 Itens"
 		navigationBar.pushNavigationItem(item, animated: true)
 	}
 }

--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -308,7 +308,6 @@ public class NavigationBar : UINavigationBar {
         if "" != item.detail {
             item.detailLabel = detailLabel
             item.detailLabel?.text = item.detail
-            item.detailLabel?.font = titleTextAttributes?[NSSecondaryFontAttributeName] as? UIFont
             item.detailLabel?.textColor = titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
             item.detailLabel?.textAlignment = .Left
         }

--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -354,8 +354,9 @@ public class NavigationBar : UINavigationBar {
 			}
 			leftSpacer.width = inset + contentInset.left
 		}
-		
-		item.titleView?.frame.size.height = height - contentInset.top - contentInset.bottom
+        
+        let _h = height > 44 ? height + inset : height
+        item.titleView?.frame.size.height = _h - contentInset.top - contentInset.bottom
 		
 		if "" != item.title {
 			if 32 >= height || "" == item.detail {

--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -354,7 +354,6 @@ public class NavigationBar : UINavigationBar {
 			leftSpacer.width = inset + contentInset.left
 		}
 		
-		item.titleView?.frame.size.width = width
 		item.titleView?.frame.size.height = height - contentInset.top - contentInset.bottom
 		
 		if let t: UILabel = item.titleLabel {

--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -53,10 +53,6 @@ public class NavigationBar : UINavigationBar {
 	
 	/// Reference to the backButton.
     public private(set) lazy var backButton: FlatButton = FlatButton()
-    
-    public private(set) lazy var titleLabel: UILabel = UILabel()
-    
-    public private(set) lazy var detailLabel: UILabel = UILabel()
 	
 	/**
 	The back button image writes to the backIndicatorImage property and
@@ -265,12 +261,12 @@ public class NavigationBar : UINavigationBar {
 	}
 	
 	public override func layoutSubviews() {
-		super.layoutSubviews()
+        super.layoutSubviews()
+        if let v: UINavigationItem = backItem {
+            layoutNavigationItem(v)
+        }
+        
 		if let v: UINavigationItem = topItem {
-			layoutNavigationItem(v)
-		}
-		
-		if let v: UINavigationItem = backItem {
 			layoutNavigationItem(v)
 		}
 	}
@@ -297,20 +293,6 @@ public class NavigationBar : UINavigationBar {
 			item.leftBarButtonItems = n.reverse()
 		}
         
-        if "" != item.title {
-            item.titleLabel = titleLabel
-            item.titleLabel?.text = item.title
-            item.titleLabel?.font = titleTextAttributes?[NSFontAttributeName] as? UIFont
-            item.titleLabel?.textColor = titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
-            item.titleLabel?.textAlignment = .Left
-        }
-        
-        if "" != item.detail {
-            item.detailLabel = detailLabel
-            item.detailLabel?.text = item.detail
-            item.detailLabel?.textColor = titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
-            item.detailLabel?.textAlignment = .Left
-        }
 		
 		// Set the titleView
         if nil == item.titleView {
@@ -319,21 +301,22 @@ public class NavigationBar : UINavigationBar {
             item.titleView!.grid.axis.direction = .Vertical
         }
         
-        // TitleView alignment.
-        if let t: UILabel = item.titleLabel {
-            t.grid.rows = 1
-            item.titleView!.addSubview(t)
+        if "" != item.title {
+            item.titleLabel!.text = item.title
+            item.titleLabel!.grid.rows = 1
+            item.titleView!.addSubview(item.titleLabel!)
             
-            if let d: UILabel = item.detailLabel {
-                d.grid.rows = 1
-                item.titleView!.addSubview(d)
-                item.titleView!.grid.views = [t, d]
+            if "" != item.detail {
+                item.detailLabel!.text = item.detail
+                item.detailLabel!.grid.rows = 1
+                item.titleView!.addSubview(item.detailLabel!)
+                item.titleView!.grid.views = [item.titleLabel!, item.detailLabel!]
             } else {
-                item.titleView!.grid.views = [t]
+                item.detailLabel!.removeFromSuperview()
+                item.titleView!.grid.views = [item.titleLabel!]
             }
         } else if let d: UIView = item.detailView {
             d.grid.rows = 1
-            item.titleView!.addSubview(d)
             item.titleView!.grid.views = [d]
         }
 		
@@ -374,19 +357,12 @@ public class NavigationBar : UINavigationBar {
 		
 		item.titleView?.frame.size.height = height - contentInset.top - contentInset.bottom
 		
-		if let t: UILabel = item.titleLabel {
-			if 32 >= height || nil == item.detailLabel {
+		if "" != item.title {
+			if 32 >= height || "" == item.detail {
 				item.detailLabel?.hidden = true
 				item.titleView?.grid.axis.rows = 1
-            } else if let d: UILabel = item.detailLabel {
-                var detailFont = titleTextAttributes?[NSSecondaryFontAttributeName] as? UIFont
-                if nil == detailFont {
-                    detailFont = titleLabel.font.fontWithSize(titleLabel.font.pointSize-2)
-                }
-				d.font = detailFont
-				
-				d.hidden = false
-				
+            } else if "" != item.detail {
+				item.detailLabel!.hidden = false
 				item.titleView?.grid.axis.rows = 2
 			}
 		} else if let _: UIView = item.detailView {

--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -41,6 +41,7 @@ public extension UINavigationBar {
 		}
 	}
 }
+public let NSSecondaryFontAttributeName = "NSSecondaryFontAttributeName"
 
 @IBDesignable
 public class NavigationBar : UINavigationBar {
@@ -51,7 +52,11 @@ public class NavigationBar : UINavigationBar {
 	private var rightSpacer: UIBarButtonItem = UIBarButtonItem(barButtonSystemItem: .FixedSpace, target: nil, action: nil)
 	
 	/// Reference to the backButton.
-	public private(set) lazy var backButton: FlatButton = FlatButton()
+    public private(set) lazy var backButton: FlatButton = FlatButton()
+    
+    public private(set) lazy var titleLabel: UILabel = UILabel()
+    
+    public private(set) lazy var detailLabel: UILabel = UILabel()
 	
 	/**
 	The back button image writes to the backIndicatorImage property and
@@ -262,11 +267,11 @@ public class NavigationBar : UINavigationBar {
 	public override func layoutSubviews() {
 		super.layoutSubviews()
 		if let v: UINavigationItem = topItem {
-			sizeNavigationItem(v)
+			layoutNavigationItem(v)
 		}
 		
 		if let v: UINavigationItem = backItem {
-			sizeNavigationItem(v)
+			layoutNavigationItem(v)
 		}
 	}
 	
@@ -291,33 +296,47 @@ public class NavigationBar : UINavigationBar {
 			n.append(leftSpacer)
 			item.leftBarButtonItems = n.reverse()
 		}
+        
+        if "" != item.title {
+            item.titleLabel = titleLabel
+            item.titleLabel?.text = item.title
+            item.titleLabel?.font = titleTextAttributes?[NSFontAttributeName] as? UIFont
+            item.titleLabel?.textColor = titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+            item.titleLabel?.textAlignment = .Left
+        }
+        
+        if "" != item.detail {
+            item.detailLabel = detailLabel
+            item.detailLabel?.text = item.detail
+            item.detailLabel?.font = titleTextAttributes?[NSSecondaryFontAttributeName] as? UIFont
+            item.detailLabel?.textColor = titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+            item.detailLabel?.textAlignment = .Left
+        }
 		
-		// Set the titleView if title is empty.
-		if "" == item.title {
-			if nil == item.titleView {
-				item.titleView = UIView(frame: CGRectMake(0, contentInset.top, MaterialDevice.width < MaterialDevice.height ? MaterialDevice.height : MaterialDevice.width, intrinsicContentSize().height - contentInset.top - contentInset.bottom))
-				item.titleView!.autoresizingMask = [.FlexibleWidth]
-				item.titleView!.grid.axis.direction = .Vertical
-			}
-			
-			// TitleView alignment.
-			if let t: UILabel = item.titleLabel {
-				t.grid.rows = 1
-				item.titleView!.addSubview(t)
-				
-				if let d: UILabel = item.detailLabel {
-					d.grid.rows = 1
-					item.titleView!.addSubview(d)
-					item.titleView!.grid.views = [t, d]
-				} else {
-					item.titleView!.grid.views = [t]
-				}
-			} else if let d: UIView = item.detailView {
-				d.grid.rows = 1
-				item.titleView!.addSubview(d)
-				item.titleView!.grid.views = [d]
-			}
-		}
+		// Set the titleView
+        if nil == item.titleView {
+            item.titleView = UIView(frame: CGRectMake(0, contentInset.top, MaterialDevice.width < MaterialDevice.height ? MaterialDevice.height : MaterialDevice.width, intrinsicContentSize().height - contentInset.top - contentInset.bottom))
+            item.titleView!.autoresizingMask = [.FlexibleWidth]
+            item.titleView!.grid.axis.direction = .Vertical
+        }
+        
+        // TitleView alignment.
+        if let t: UILabel = item.titleLabel {
+            t.grid.rows = 1
+            item.titleView!.addSubview(t)
+            
+            if let d: UILabel = item.detailLabel {
+                d.grid.rows = 1
+                item.titleView!.addSubview(d)
+                item.titleView!.grid.views = [t, d]
+            } else {
+                item.titleView!.grid.views = [t]
+            }
+        } else if let d: UIView = item.detailView {
+            d.grid.rows = 1
+            item.titleView!.addSubview(d)
+            item.titleView!.grid.views = [d]
+        }
 		
 		// rightControls
 		if let v: Array<UIControl> = item.rightControls {
@@ -358,15 +377,16 @@ public class NavigationBar : UINavigationBar {
 		
 		if let t: UILabel = item.titleLabel {
 			if 32 >= height || nil == item.detailLabel {
-				t.font = t.font.fontWithSize(20)
-				
 				item.detailLabel?.hidden = true
 				item.titleView?.grid.axis.rows = 1
-			} else if let d: UILabel = item.detailLabel {
-				t.font = t.font.fontWithSize(17)
+            } else if let d: UILabel = item.detailLabel {
+                var detailFont = titleTextAttributes?[NSSecondaryFontAttributeName] as? UIFont
+                if nil == detailFont {
+                    detailFont = titleLabel.font.fontWithSize(titleLabel.font.pointSize-2)
+                }
+				d.font = detailFont
 				
 				d.hidden = false
-				d.font = d.font.fontWithSize(12)
 				
 				item.titleView?.grid.axis.rows = 2
 			}
@@ -413,9 +433,12 @@ public class NavigationBar : UINavigationBar {
 	}
 	
 	/// Prepares the UINavigationItem for layout and sizing.
-	internal func prepareItem(item: UINavigationItem) {
-		if nil == item.title {
-			item.title = ""
-		}
+    internal func prepareItem(item: UINavigationItem) {
+        if nil == item.title {
+            item.title = ""
+        }
+        if nil == item.detail {
+            item.detail = ""
+        }
 	}
 }

--- a/Sources/iOS/NavigationController.swift
+++ b/Sources/iOS/NavigationController.swift
@@ -80,16 +80,6 @@ public class NavigationController : UINavigationController, UIGestureRecognizerD
 		}
 	}
 	
-	public override func viewDidAppear(animated: Bool) {
-		super.viewDidAppear(animated)
-		// Load the initial topItem.
-		if let v: NavigationBar = navigationBar as? NavigationBar {
-			if let item: UINavigationItem = v.topItem {
-				v.layoutNavigationItem(item)
-			}
-		}
-	}
-	
 	/**
 	Detects the gesture recognizer being used. This is necessary when using 
 	SideNavigationController. It eliminates the conflict in panning.

--- a/Sources/iOS/NavigationItem.swift
+++ b/Sources/iOS/NavigationItem.swift
@@ -45,12 +45,46 @@ public class MaterialAssociatedObjectNavigationItem {
     
     /// Detail Text.
     public var detail: String?
-	
-	/// Title label.
-	public var titleLabel: UILabel?
-	
-	/// Detail label.
-	public var detailLabel: UILabel?
+    
+    public private(set) lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        let titleTextAttributes = UINavigationBar.appearance().titleTextAttributes
+        
+        if let font = titleTextAttributes?[NSFontAttributeName] as? UIFont {
+            label.font = font
+        }
+        
+        if let color = titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor {
+            label.textColor = color
+        }
+        
+        if let paragraphStyle = titleTextAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle {
+            label.textAlignment = paragraphStyle.alignment
+        }
+        
+        return label
+    }()
+    
+    public private(set) lazy var detailLabel: UILabel = {
+        let label = UILabel()
+        let titleTextAttributes = UINavigationBar.appearance().titleTextAttributes
+        
+        if let font = titleTextAttributes?[NSSecondaryFontAttributeName] as? UIFont {
+            label.font = font
+        } else if let titleFont = titleTextAttributes?[NSFontAttributeName] as? UIFont{
+            label.font = titleFont.fontWithSize(titleFont.pointSize-2)
+        }
+        
+        if let color = titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor {
+            label.textColor = color
+        }
+        
+        if let paragraphStyle = titleTextAttributes?[NSParagraphStyleAttributeName] as? NSParagraphStyle {
+            label.textAlignment = paragraphStyle.alignment
+        }
+        
+        return label
+    }()
 	
 	/// Left controls.
 	public var leftControls: Array<UIControl>?
@@ -112,18 +146,12 @@ public extension UINavigationItem {
 		get {
 			return item.titleLabel
 		}
-		set(value) {
-			item.titleLabel = value
-		}
 	}
 	
     /// Detail Label.
     public var detailLabel: UILabel? {
         get {
             return item.detailLabel
-        }
-        set(value) {
-            item.detailLabel = value
         }
     }
     

--- a/Sources/iOS/NavigationItem.swift
+++ b/Sources/iOS/NavigationItem.swift
@@ -38,10 +38,13 @@ public class MaterialAssociatedObjectNavigationItem {
 	public var portraitInset: CGFloat
 	
 	/// Landscape inset.
-	public var landscapeInset: CGFloat
-	
-	/// Detail View.
-	public var detailView: UIView?
+    public var landscapeInset: CGFloat
+    
+    /// Detail View.
+    public var detailView: UIView?
+    
+    /// Detail Text.
+    public var detail: String?
 	
 	/// Title label.
 	public var titleLabel: UILabel?
@@ -114,15 +117,24 @@ public extension UINavigationItem {
 		}
 	}
 	
-	/// Detail Label.
-	public var detailLabel: UILabel? {
-		get {
-			return item.detailLabel
-		}
-		set(value) {
-			item.detailLabel = value
-		}
-	}
+    /// Detail Label.
+    public var detailLabel: UILabel? {
+        get {
+            return item.detailLabel
+        }
+        set(value) {
+            item.detailLabel = value
+        }
+    }
+    
+    public var detail: String? {
+        get {
+            return item.detail
+        }
+        set(value) {
+            item.detail = value
+        }
+    }
 	
 	/// Left side UIControls.
 	public var leftControls: Array<UIControl>? {


### PR DESCRIPTION
Now `navigationBarItem` not need assign `titleLabel` and `detailLabel`, to show those elements, only need set `viewController.title` or `navigationItem.title` and `navigationItem.detail`, related on #313 

Revised to the titleView overlap the `rightControls` on `navigationBar`.

Now title and detail font are setted from `UINavigationBar.appearance().titleTextAttributes`, a new key was added for the `detailLabel` font `NSSecondaryFontAttributeName` related on #277 

I think that's all

Ps.: Sorry for the last PR erroneously sent