### PR TITLE
Add pulseCenter property to MaterialButton

### DIFF
--- a/Sources/iOS/MaterialButton.swift
+++ b/Sources/iOS/MaterialButton.swift
@@ -55,11 +55,14 @@ public class MaterialButton : UIButton {
 	/// Sets whether the scaling animation should be used.
 	@IBInspectable public lazy var pulseScale: Bool = true
 	
-	/// The opcaity value for the pulse animation.
+	/// The opacity value for the pulse animation.
 	@IBInspectable public var pulseOpacity: CGFloat = 0.25
 	
 	/// The color of the pulse effect.
 	@IBInspectable public var pulseColor: UIColor?
+	
+	/// Sets a pulse animation to always radiate from the center
+	@IBInspectable public var pulseCenter: Bool = false
 	
 	/**
 	This property is the same as clipsToBounds. It crops any of the view's
@@ -436,13 +439,14 @@ public class MaterialButton : UIButton {
 	public override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
 		super.touchesBegan(touches, withEvent: event)
 		let duration: NSTimeInterval = MaterialAnimation.pulseDuration(width)
+		let point: CGPoint = pulseCenter ? CGPointMake(CGFloat(width / 2), CGFloat(height / 2)) : layer.convertPoint(touches.first!.locationInView(self), fromLayer: layer)
 		
 		if pulseFocus {
 			pulseLayer = CAShapeLayer()
 		}
 		
 		if let v: UIColor = pulseColor {
-			MaterialAnimation.pulseAnimation(layer, visualLayer: visualLayer, color: v.colorWithAlphaComponent(pulseOpacity), point: layer.convertPoint(touches.first!.locationInView(self), fromLayer: layer), width: width, height: height, duration: duration, pulseLayer: pulseLayer)
+			MaterialAnimation.pulseAnimation(layer, visualLayer: visualLayer, color: v.colorWithAlphaComponent(pulseOpacity), point: point, width: width, height: height, duration: duration, pulseLayer: pulseLayer)
 		}
 		
 		if pulseScale {


### PR DESCRIPTION
Adds a pulseCenter property that forces pulse to always radiate from the center of a button

This effect can be seen in some apps (such as the dialer of Hangouts app on iOS). It's primarily useful for circular flat buttons without background/borders, where having a pulse start from the user's touch location makes the element look broken.

With pulseCenter = true:
https://cdn.pbrd.co/images/jmlTjX1.png

With pulseCenter = false (default, for backwards compatibility):
https://cdn.pbrd.co/images/jmtbjIr.png