### PR TITLE
prepareView func should not be private

### DIFF
--- a/Sources/iOS/TextView.swift
+++ b/Sources/iOS/TextView.swift
@@ -466,7 +466,7 @@ public class TextView: UITextView {
 	The super.prepareView method should always be called immediately
 	when subclassing.
 	*/
-	private func prepareView() {
+	public func prepareView() {
 		textContainerInset = MaterialEdgeInsetToValue(.None)
 		backgroundColor = MaterialColor.white
 		masksToBounds = false


### PR DESCRIPTION
According to prepareView func's description it should not be private because it can't be overridden in a subclass