### PR TITLE
Fix panGesture bug when moveRowAtIndexpath on tableview in rootViewController

### DIFF
--- a/Sources/iOS/SideNavigationController.swift
+++ b/Sources/iOS/SideNavigationController.swift
@@ -675,21 +675,21 @@ public class SideNavigationController : UIViewController, UIGestureRecognizerDel
 	- Parameter touch: The UITouch event.
 	- Returns: A Boolean of whether to continue the gesture or not.
 	*/
-	public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldReceiveTouch touch: UITouch) -> Bool {
-		if !openedRightView && gestureRecognizer == panLeftViewGesture && (openedLeftView || isPointContainedWithinLeftThreshold(touch.locationInView(view))) {
-			return true
-		}
-		if !openedLeftView && gestureRecognizer == panRightViewGesture && (openedRightView || isPointContainedWithinRighThreshold(touch.locationInView(view))) {
-			return true
-		}
-		if openedLeftView && gestureRecognizer == tapLeftViewGesture {
-			return true
-		}
-		if openedRightView && gestureRecognizer == tapRightViewGesture {
-			return true
-		}
-		return false
-	}
+    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldReceiveTouch touch: UITouch) -> Bool {
+        if !openedRightView && gestureRecognizer == panLeftViewGesture && (openedLeftView || isPointContainedWithinLeftThreshold(touch.locationInView(view))) && leftView != nil {
+            return true
+        }
+        if !openedLeftView && gestureRecognizer == panRightViewGesture && (openedRightView || isPointContainedWithinRighThreshold(touch.locationInView(view))) && rightView != nil {
+            return true
+        }
+        if openedLeftView && gestureRecognizer == tapLeftViewGesture {
+            return true
+        }
+        if openedRightView && gestureRecognizer == tapRightViewGesture {
+            return true
+        }
+        return false
+    }
 	
 	/**
 	A method that is fired when the pan gesture is recognized

--- a/Sources/iOS/SideNavigationController.swift
+++ b/Sources/iOS/SideNavigationController.swift
@@ -675,21 +675,21 @@ public class SideNavigationController : UIViewController, UIGestureRecognizerDel
 	- Parameter touch: The UITouch event.
 	- Returns: A Boolean of whether to continue the gesture or not.
 	*/
-    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldReceiveTouch touch: UITouch) -> Bool {
-        if !openedRightView && gestureRecognizer == panLeftViewGesture && (openedLeftView || isPointContainedWithinLeftThreshold(touch.locationInView(view))) && leftView != nil {
-            return true
-        }
-        if !openedLeftView && gestureRecognizer == panRightViewGesture && (openedRightView || isPointContainedWithinRighThreshold(touch.locationInView(view))) && rightView != nil {
-            return true
-        }
-        if openedLeftView && gestureRecognizer == tapLeftViewGesture {
-            return true
-        }
-        if openedRightView && gestureRecognizer == tapRightViewGesture {
-            return true
-        }
-        return false
-    }
+    	public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldReceiveTouch touch: UITouch) -> Bool {
+        	if !openedRightView && gestureRecognizer == panLeftViewGesture && (openedLeftView || isPointContainedWithinLeftThreshold(touch.locationInView(view))) && leftView != nil {
+            		return true
+        	}
+        	if !openedLeftView && gestureRecognizer == panRightViewGesture && (openedRightView || isPointContainedWithinRighThreshold(touch.locationInView(view))) && rightView != nil {
+            		return true
+        	}
+        	if openedLeftView && gestureRecognizer == tapLeftViewGesture {
+        	   	return true
+        	}
+        	if openedRightView && gestureRecognizer == tapRightViewGesture {
+            		return true
+        	}
+        	return false
+    	}
 	
 	/**
 	A method that is fired when the pan gesture is recognized


### PR DESCRIPTION
Hi,
After your update on issue #322, I still had a problem when I wanted to use `moveRowAtIndexPath` on a tableview inside the rootViewController.

**👾 Reproduce Bug**
- Instantiate a UITableviewController as the rootViewController.
- Create cells with the feature 
`tableView(tableView: UITableView, moveRowAtIndexPath fromIndexPath: NSIndexPath, toIndexPath: NSIndexPath)`
- Try to move a cell, sometimes it will move, and almost always it will look like the pangesture is cancelled


**🔮 Explanation**
After some research, I found out that
`public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldReceiveTouch touch: UITouch) -> Bool`
inside SideNavigationController.swift (line 678) was the reason that sometimes, the `moveRowAtIndexPath` method was cancelled.

Why ? Even though I only instantiate a leftView, the check for the panGesture is still being made with the righView threeshold: Especially with this `if` statement:

`if !openedLeftView && gestureRecognizer == panRightViewGesture && (openedRightView || isPointContainedWithinRighThreshold(touch.locationInView(view))) {
			return true
		}`


**✅ Resolution**
Adding `&& rightView != nil` in the `if` statement, will resolve the problem **only if we are not using rightView**


**Note**
If the developer wanted to use both the `moveRowAtIndexPath` and a rightView, this solution will not work for them. But I have a suggestion that need to be discussed with you people:

The only way I see to resolve completely the problem is like this:

- Remove `&& rightView != nil` inside the `if` statement
- Add those methods for your UITableViewController

```
func tableView(tableView: UITableView, willBeginReorderingRowAtIndexPath indexPath: NSIndexPath) {
        self.sideNavigationController?.enabledRightView = false
    }

```
```
func tableView(tableView: UITableView, didEndReorderingRowAtIndexPath indexPath: NSIndexPath) {
        self.sideNavigationController?.enabledRightView = true
    }
```
- And it will work **BUT** those methods are undocumented UITableView Delegates on Apple docs. It doesn't seems to be part of private API so I can be accepted for Apple review (I'm not 100% sure, be aware ⚠️)

That's all for me, sorry for the long post ^^''