### PR TITLE
PhotoLibrary integration from Apple's PHPhotoLibrary.

### DIFF
--- a/Sources/iOS/Material+UIImage.swift
+++ b/Sources/iOS/Material+UIImage.swift
@@ -36,7 +36,7 @@ public enum ImageFormat: Int {
 	case jpeg
 }
 
-public extension UIImage {
+extension UIImage {
     /// Width of the UIImage.
     public var width: CGFloat {
         return size.width
@@ -48,7 +48,7 @@ public extension UIImage {
     }
 }
 
-public extension UIImage {
+extension UIImage {
     /**
      Resizes an image based on a given width.
      - Parameter toWidth w: A width value.
@@ -94,7 +94,7 @@ public extension UIImage {
     }
 }
 
-public extension UIImage {
+extension UIImage {
     /**
      Creates a new image with the passed in color.
      - Parameter color: The UIColor to create the image from.
@@ -122,7 +122,7 @@ public extension UIImage {
     }
 }
 
-public extension UIImage {
+extension UIImage {
     /**
      Creates an Image that is a color.
      - Parameter color: The UIColor to create the image from.
@@ -140,7 +140,7 @@ public extension UIImage {
     }
 }
 
-public extension UIImage {
+extension UIImage {
     /**
      Crops an image to a specified width and height.
      - Parameter toWidth tw: A specified width.
@@ -165,7 +165,7 @@ public extension UIImage {
     }
 }
 
-public extension UIImage {
+extension UIImage {
     /**
      Creates an clear image.
      - Returns: A UIImage that is clear.
@@ -178,7 +178,7 @@ public extension UIImage {
     }
 }
 
-public extension UIImage {
+extension UIImage {
     /**
      Asynchronously load images with a completion block.
      - Parameter URL: A URL destination to fetch the image from.
@@ -198,7 +198,7 @@ public extension UIImage {
     }
 }
 
-public extension UIImage {
+extension UIImage {
     /**
      Adjusts the orientation of the image from the capture orientation.
      This is an issue when taking images, the capture orientation is not set correctly

--- a/Sources/iOS/PhotoLibrary.swift
+++ b/Sources/iOS/PhotoLibrary.swift
@@ -434,6 +434,26 @@ extension PhotoLibrary {
     }
 }
 
+/// Fetch.
+extension PhotoLibrary {
+    /**
+     Fetches generic type T for a given PHFetchResult<T>.
+     - Parameter fetchResult: A PHFetchResult<T>.
+     - Parameter completion: A completion block.
+     */
+    private func fetch<T: PHFetchResult<U>, U: PHObject>(result: T, completion: ([U], T) -> Void) {
+        var objects = [U]()
+        
+        result.enumerateObjects({ (collection, _, _) in
+            objects.append(collection)
+        })
+        
+        DispatchQueue.main.async { [objects = objects, result = result, completion = completion] in
+            completion(objects, result)
+        }
+    }
+}
+
 /// PHCollectionList.
 extension PhotoLibrary {
     /**
@@ -446,7 +466,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchCollectionListsContaining(_ collection: PHCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetchCollectionLists(fetchResult: PHCollectionList.fetchCollectionListsContaining(collection, options: options), completion: completion)
+        fetch(result: PHCollectionList.fetchCollectionListsContaining(collection, options: options), completion: completion)
     }
     
     /**
@@ -457,7 +477,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchCollectionList(with type: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetchCollectionLists(fetchResult: PHCollectionList.fetchCollectionLists(with: type, subtype: subtype, options: options), completion: completion)
+        fetch(result: PHCollectionList.fetchCollectionLists(with: type, subtype: subtype, options: options), completion: completion)
     }
     
     /**
@@ -470,7 +490,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchCollectionLists(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetchCollectionLists(fetchResult: PHCollectionList.fetchCollectionLists(withLocalIdentifiers: identifiers, options: options), completion: completion)
+        fetch(result: PHCollectionList.fetchCollectionLists(withLocalIdentifiers: identifiers, options: options), completion: completion)
     }
     
     /**
@@ -483,7 +503,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchCollectionLists(with collectionListType: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetchCollectionLists(fetchResult: PHCollectionList.fetchCollectionLists(with: collectionListType, subtype: subtype, options: options), completion: completion)
+        fetch(result: PHCollectionList.fetchCollectionLists(with: collectionListType, subtype: subtype, options: options), completion: completion)
     }
     
     /**
@@ -494,7 +514,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, containingMoment moment: PHAssetCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetchCollectionLists(fetchResult: PHCollectionList.fetchMomentLists(with: momentListSubtype, containingMoment: moment, options: options), completion: completion)
+        fetch(result: PHCollectionList.fetchMomentLists(with: momentListSubtype, containingMoment: moment, options: options), completion: completion)
     }
     
     /**
@@ -504,24 +524,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetchCollectionLists(fetchResult: PHCollectionList.fetchMomentLists(with: momentListSubtype, options: options), completion: completion)
-    }
-    
-    /**
-     Fetches PHCollectionLists for a given PHFetchResult<PHCollectionList>.
-     - Parameter fetchResult: A PHFetchResult<PHCollectionList>.
-     - Parameter completion: A completion block.
-     */
-    private func fetchCollectionLists(fetchResult: PHFetchResult<PHCollectionList>, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        var lists = [PHCollectionList]()
-        
-        fetchResult.enumerateObjects({ (list, _, _) in
-            lists.append(list)
-        })
-        
-        DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
-            completion(lists, fetchResult)
-        }
+        fetch(result: PHCollectionList.fetchMomentLists(with: momentListSubtype, options: options), completion: completion)
     }
 }
 
@@ -534,7 +537,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchCollections(in collectionList: PHCollectionList, options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
-        fetchCollections(fetchResult: PHCollection.fetchCollections(in: collectionList, options: options), completion: completion)
+        fetch(result: PHCollection.fetchCollections(in: collectionList, options: options), completion: completion)
     }
     
     /**
@@ -545,24 +548,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchTopLevelUserCollections(with options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
-        fetchCollections(fetchResult: PHCollection.fetchTopLevelUserCollections(with: nil), completion: completion)
-    }
-    
-    /**
-     Fetches PHCollections for a given PHFetchResult<PHCollection>.
-     - Parameter fetchResult: A PHFetchResult<PHCollection>.
-     - Parameter completion: A completion block.
-     */
-    private func fetchCollections(fetchResult: PHFetchResult<PHCollection>, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
-        var collections = [PHCollection]()
-        
-        fetchResult.enumerateObjects({ (collection, _, _) in
-            collections.append(collection)
-        })
-        
-        DispatchQueue.main.async { [collections = collections, fetchResult = fetchResult, completion = completion] in
-            completion(collections, fetchResult)
-        }
+        fetch(result: PHCollection.fetchTopLevelUserCollections(with: nil), completion: completion)
     }
 }
 
@@ -576,7 +562,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssetCollections(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetchAssetCollections(fetchResult: PHAssetCollection.fetchAssetCollections(withLocalIdentifiers: identifiers, options: options), completion: completion)
+        fetch(result: PHAssetCollection.fetchAssetCollections(withLocalIdentifiers: identifiers, options: options), completion: completion)
     }
     
     /**
@@ -588,7 +574,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssetCollections(with type: PHAssetCollectionType, subtype: PHAssetCollectionSubtype, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetchAssetCollections(fetchResult: PHAssetCollection.fetchAssetCollections(with: type, subtype: subtype, options: options), completion: completion)
+        fetch(result: PHAssetCollection.fetchAssetCollections(with: type, subtype: subtype, options: options), completion: completion)
     }
     
     /**
@@ -599,7 +585,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssetCollectionsContaining(_ asset: PHAsset, with type: PHAssetCollectionType, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetchAssetCollections(fetchResult: PHAssetCollection.fetchAssetCollectionsContaining(asset, with: type, options: options), completion: completion)
+        fetch(result: PHAssetCollection.fetchAssetCollectionsContaining(asset, with: type, options: options), completion: completion)
     }
     
     /**
@@ -611,7 +597,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssetCollections(withALAssetGroupURLs assetGroupURLs: [URL], options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetchAssetCollections(fetchResult: PHAssetCollection.fetchAssetCollections(withALAssetGroupURLs: assetGroupURLs, options: options), completion: completion)
+        fetch(result: PHAssetCollection.fetchAssetCollections(withALAssetGroupURLs: assetGroupURLs, options: options), completion: completion)
     }
     
     /**
@@ -621,7 +607,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchMoments(inMomentList momentList: PHCollectionList, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetchAssetCollections(fetchResult: PHAssetCollection.fetchMoments(inMomentList: momentList, options: options), completion: completion)
+        fetch(result: PHAssetCollection.fetchMoments(inMomentList: momentList, options: options), completion: completion)
     }
     
     /**
@@ -630,24 +616,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchMoments(with options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetchAssetCollections(fetchResult: PHAssetCollection.fetchMoments(with: options), completion: completion)
-    }
-    
-    /**
-     Fetches PHAssetCollections for a given PHFetchResult<PHAssetCollection>.
-     - Parameter fetchResult: A PHFetchResult<PHAssetCollection>.
-     - Parameter completion: A completion block.
-     */
-    private func fetchAssetCollections(fetchResult: PHFetchResult<PHAssetCollection>, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        var collections = [PHAssetCollection]()
-        
-        fetchResult.enumerateObjects({ (collection, _, _) in
-            collections.append(collection)
-        })
-        
-        DispatchQueue.main.async { [collections = collections, fetchResult = fetchResult, completion = completion] in
-            completion(collections, fetchResult)
-        }
+        fetch(result: PHAssetCollection.fetchMoments(with: options), completion: completion)
     }
 }
 
@@ -660,7 +629,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssets(in assetCollection: PHAssetCollection, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetchAssets(fetchResult: PHAsset.fetchAssets(in: assetCollection, options: options), completion: completion)
+        fetch(result: PHAsset.fetchAssets(in: assetCollection, options: options), completion: completion)
     }
     
     /**
@@ -671,7 +640,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssets(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetchAssets(fetchResult: PHAsset.fetchAssets(withLocalIdentifiers: identifiers, options: options), completion: completion)
+        fetch(result: PHAsset.fetchAssets(withLocalIdentifiers: identifiers, options: options), completion: completion)
     }
     
     /**
@@ -685,7 +654,7 @@ extension PhotoLibrary {
         guard let fetchResult = PHAsset.fetchKeyAssets(in: assetCollection, options: options) else {
             return nil
         }
-        fetchAssets(fetchResult: fetchResult, completion: completion)
+        fetch(result: fetchResult, completion: completion)
         return fetchResult
     }
     
@@ -697,7 +666,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssets(withBurstIdentifier burstIdentifier: String, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetchAssets(fetchResult: PHAsset.fetchAssets(withBurstIdentifier: burstIdentifier, options: options), completion: completion)
+        fetch(result: PHAsset.fetchAssets(withBurstIdentifier: burstIdentifier, options: options), completion: completion)
     }
     
     /**
@@ -707,7 +676,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssets(with options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetchAssets(fetchResult: PHAsset.fetchAssets(with: options), completion: completion)
+        fetch(result: PHAsset.fetchAssets(with: options), completion: completion)
     }
     
     /**
@@ -717,7 +686,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssets(with mediaType: PHAssetMediaType, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetchAssets(fetchResult: PHAsset.fetchAssets(with: mediaType, options: options), completion: completion)
+        fetch(result: PHAsset.fetchAssets(with: mediaType, options: options), completion: completion)
     }
     
     /**
@@ -728,24 +697,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssets(withALAssetURLs assetURLs: [URL], options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetchAssets(fetchResult: PHAsset.fetchAssets(withALAssetURLs: assetURLs, options: options), completion: completion)
-    }
-    
-    /**
-     Fetches PHAssets for a given PHFetchResult<PHAsset>.
-     - Parameter fetchResult: A PHFetchResult<PHAsset>.
-     - Parameter completion: A completion block.
-     */
-    private func fetchAssets(fetchResult: PHFetchResult<PHAsset>, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        var assets = [PHAsset]()
-        
-        fetchResult.enumerateObjects({ (asset, _, _) in
-            assets.append(asset)
-        })
-        
-        DispatchQueue.main.async { [assets = assets, fetchResult = fetchResult, completion = completion] in
-            completion(assets, fetchResult)
-        }
+        fetch(result: PHAsset.fetchAssets(withALAssetURLs: assetURLs, options: options), completion: completion)
     }
 }
 

--- a/Sources/iOS/PhotoLibrary.swift
+++ b/Sources/iOS/PhotoLibrary.swift
@@ -437,24 +437,40 @@ extension PhotoLibrary {
 /// PHCollection.
 extension PhotoLibrary {
     /**
-     Fetch PHCollection based on a type and subtype.
+     Fetches PHCollections in a given PHCollectionList.
+     - Parameter in collectionList: A PHCollectionList.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchCollections(in collectionList: PHCollectionList, options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
+        fetchCollections(fetchResult: PHCollection.fetchCollections(in: collectionList, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches PHCollections based on a type and subtype.
      - Parameter with type: A PHCollectionListType.
      - Parameter subtype: A PHCollectionListSubtype.
      - Parameter options: An optional PHFetchOptions object.
      - Parameter completion: A completion callback.
      */
     public func fetchTopLevelUserCollections(with options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
+        fetchCollections(fetchResult: PHCollection.fetchTopLevelUserCollections(with: nil), completion: completion)
+    }
+    
+    /**
+     Fetches the PHCollections for a given PHFetchResult<PHCollection>.
+     - Parameter fetchResult: A PHFetchResult<PHCollection>.
+     - Parameter completion: A completion block.
+     */
+    private func fetchCollections(fetchResult: PHFetchResult<PHCollection>, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
         var collections = [PHCollection]()
-        let fetchResult = PHCollection.fetchTopLevelUserCollections(with: nil)
         
-        defer {
-            DispatchQueue.main.async { [collections = collections, fetchResult = fetchResult, completion = completion] in
-                completion(collections, fetchResult)
-            }
-        }
-        
-        fetchResult.enumerateObjects(options: [.concurrent]) { (collection, _, _) in
+        fetchResult.enumerateObjects({ (collection, _, _) in
             collections.append(collection)
+        })
+        
+        DispatchQueue.main.async { [collections = collections, fetchResult = fetchResult, completion = completion] in
+            completion(collections, fetchResult)
         }
     }
 }
@@ -471,18 +487,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchCollectionListsContaining(_ collection: PHCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        var lists = [PHCollectionList]()
-        let fetchResult = PHCollectionList.fetchCollectionListsContaining(collection, options: options)
-        
-        defer {
-            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
-                completion(lists, fetchResult)
-            }
-        }
-        
-        fetchResult.enumerateObjects({ (list, _, _) in
-            lists.append(list)
-        })
+        fetchCollectionLists(fetchResult: PHCollectionList.fetchCollectionListsContaining(collection, options: options), completion: completion)
     }
     
     /**
@@ -493,18 +498,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchCollectionList(with type: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        var lists = [PHCollectionList]()
-        let fetchResult = PHCollectionList.fetchCollectionLists(with: type, subtype: subtype, options: options)
-        
-        defer {
-            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
-                completion(lists, fetchResult)
-            }
-        }
-        
-        fetchResult.enumerateObjects({ (list, _, _) in
-            lists.append(list)
-        })
+        fetchCollectionLists(fetchResult: PHCollectionList.fetchCollectionLists(with: type, subtype: subtype, options: options), completion: completion)
     }
     
     /**
@@ -517,18 +511,7 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchCollectionLists(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        var lists = [PHCollectionList]()
-        let fetchResult = PHCollectionList.fetchCollectionLists(withLocalIdentifiers: identifiers, options: options)
-        
-        defer {
-            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
-                completion(lists, fetchResult)
-            }
-        }
-        
-        fetchResult.enumerateObjects({ (list, _, _) in
-            lists.append(list)
-        })
+        fetchCollectionLists(fetchResult: PHCollectionList.fetchCollectionLists(withLocalIdentifiers: identifiers, options: options), completion: completion)
     }
     
     /**
@@ -540,19 +523,8 @@ extension PhotoLibrary {
      - Parameter options: An optional PHFetchOptions object.
      - Parameter completion: A completion callback.
      */
-    public class func fetchCollectionLists(with collectionListType: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        var lists = [PHCollectionList]()
-        let fetchResult = PHCollectionList.fetchCollectionLists(with: collectionListType, subtype: subtype, options: options)
-        
-        defer {
-            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
-                completion(lists, fetchResult)
-            }
-        }
-        
-        fetchResult.enumerateObjects({ (list, _, _) in
-            lists.append(list)
-        })
+    public func fetchCollectionLists(with collectionListType: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        fetchCollectionLists(fetchResult: PHCollectionList.fetchCollectionLists(with: collectionListType, subtype: subtype, options: options), completion: completion)
     }
     
     /**
@@ -562,19 +534,8 @@ extension PhotoLibrary {
      - Parameter options: An optional PHFetchOptions object.
      - Parameter completion: A completion callback.
      */
-    public class func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, containingMoment moment: PHAssetCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        var lists = [PHCollectionList]()
-        let fetchResult = PHCollectionList.fetchMomentLists(with: momentListSubtype, containingMoment: moment, options: options)
-        
-        defer {
-            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
-                completion(lists, fetchResult)
-            }
-        }
-        
-        fetchResult.enumerateObjects({ (list, _, _) in
-            lists.append(list)
-        })
+    public func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, containingMoment moment: PHAssetCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        fetchCollectionLists(fetchResult: PHCollectionList.fetchMomentLists(with: momentListSubtype, containingMoment: moment, options: options), completion: completion)
     }
     
     /**
@@ -584,18 +545,24 @@ extension PhotoLibrary {
      - Parameter completion: A completion callback.
      */
     public func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        fetchCollectionLists(fetchResult: PHCollectionList.fetchMomentLists(with: momentListSubtype, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches the PHCollectionLists for a given PHFetchResult<PHCollectionList>.
+     - Parameter fetchResult: A PHFetchResult<PHCollectionList>.
+     - Parameter completion: A completion block.
+     */
+    private func fetchCollectionLists(fetchResult: PHFetchResult<PHCollectionList>, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
         var lists = [PHCollectionList]()
-        let fetchResult = PHCollectionList.fetchMomentLists(with: momentListSubtype, options: options)
-        
-        defer {
-            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
-                completion(lists, fetchResult)
-            }
-        }
         
         fetchResult.enumerateObjects({ (list, _, _) in
             lists.append(list)
         })
+        
+        DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
+            completion(lists, fetchResult)
+        }
     }
 }
 
@@ -608,21 +575,57 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssets(in assetCollection: PHAssetCollection, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        var fetchResult: PHFetchResult<PHAsset>!
-        var assets = [PHAsset]()
-        
-        defer {
-            DispatchQueue.main.async { [assets = assets, fetchResult = fetchResult, completion = completion] in
-                completion(assets, fetchResult!)
-            }
-        }
-        
-        fetchResult = PHAsset.fetchAssets(in: assetCollection, options: options)
-        
-        fetchResult.enumerateObjects({ (asset, _, _) in
-            assets.append(asset)
-        })
+        fetchAssets(fetchResult: PHAsset.fetchAssets(in: assetCollection, options: options), completion: completion)
     }
+    
+    /**
+     Fetch the PHAssets with a given Array of identifiers.
+     - Parameter withLocalIdentifiers identifiers: A Array of
+     String identifiers.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetchAssets(fetchResult: PHAsset.fetchAssets(withLocalIdentifiers: identifiers, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch key assets.
+     - Parameter in assetCollection: A PHAssetCollection.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     - Returns: An optional PHFetchResult<PHAsset> object.
+     */
+    public func fetchKeyAssets(in assetCollection: PHAssetCollection, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) -> PHFetchResult<PHAsset>? {
+        guard let fetchResult = PHAsset.fetchKeyAssets(in: assetCollection, options: options) else {
+            return nil
+        }
+        fetchAssets(fetchResult: fetchResult, completion: completion)
+        return fetchResult
+    }
+    
+    /**
+     Fetch a burst asset with a given burst identifier.
+     - Parameter withBurstIdentifier burstIdentifier: A 
+     PHAssetCollection.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(withBurstIdentifier burstIdentifier: String, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetchAssets(fetchResult: PHAsset.fetchAssets(withBurstIdentifier: burstIdentifier, options: options), completion: completion)
+    }
+    
+    
+    /**
+     Fetches PHAssetSourceTypeUserLibrary assets by default (use 
+     includeAssetSourceTypes option to override).
+     - Parameter with options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(with options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetchAssets(fetchResult: PHAsset.fetchAssets(with: options), completion: completion)
+    }
+
     
     /**
      Fetch the PHAssets with a given media type.
@@ -631,20 +634,35 @@ extension PhotoLibrary {
      - Parameter completion: A completion block.
      */
     public func fetchAssets(with mediaType: PHAssetMediaType, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        var fetchResult: PHFetchResult<PHAsset>!
+        fetchAssets(fetchResult: PHAsset.fetchAssets(with: mediaType, options: options), completion: completion)
+    }
+    
+    /**
+     AssetURLs are URLs retrieved from ALAsset's 
+     ALAssetPropertyAssetURL.
+     - Parameter withALAssetURLs assetURLs: A PHAssetMediaType.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(withALAssetURLs assetURLs: [URL], options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetchAssets(fetchResult: PHAsset.fetchAssets(withALAssetURLs: assetURLs, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches the PHAssets for a given PHFetchResult<PHAsset>.
+     - Parameter fetchResult: A PHFetchResult<PHAsset>.
+     - Parameter completion: A completion block.
+     */
+    private func fetchAssets(fetchResult: PHFetchResult<PHAsset>, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
         var assets = [PHAsset]()
-        
-        defer {
-            DispatchQueue.main.async { [assets = assets, fetchResult = fetchResult, completion = completion] in
-                completion(assets, fetchResult!)
-            }
-        }
-        
-        fetchResult = PHAsset.fetchAssets(with: mediaType, options: options)
         
         fetchResult.enumerateObjects({ (asset, _, _) in
             assets.append(asset)
         })
+        
+        DispatchQueue.main.async { [assets = assets, fetchResult = fetchResult, completion = completion] in
+            completion(assets, fetchResult)
+        }
     }
 }
 

--- a/Sources/iOS/PhotoLibrary.swift
+++ b/Sources/iOS/PhotoLibrary.swift
@@ -30,17 +30,6 @@
 
 import Photos
 
-public struct PhotoLibraryDataSource {
-    /// A reference to the calling PHFetchResult.
-    public private(set) var fetchResult: PHFetchResult<PHAsset>
-    
-    /// A reference to a PHAssetCollection returned from the fetchResult.
-    public private(set) var collection: PHAssetCollection
-    
-    /// A reference to an Array of PHAssets for the PHAssetCollection.
-    public private(set) var assets: [PHAsset]
-}
-
 @objc(PhotoLibraryMove)
 public class PhotoLibraryMove: NSObject {
     /// An index that is being moved from.
@@ -61,8 +50,11 @@ public class PhotoLibraryMove: NSObject {
 }
 
 public struct PhotoLibraryFetchResultDataSource {
-    public private(set) var fetchResult: PHFetchResult<PHObject>
-    public private(set) var objects: [PHObject]
+    /// A reference to the PHFetchResults.
+    public internal(set) var fetchResult: PHFetchResult<PHObject>
+    
+    /// A reference to the objects associated with the PHFetchResult.
+    public internal(set) var objects: [PHObject]
 }
 
 @objc(PhotoLibraryDelegate)
@@ -181,28 +173,7 @@ public class PhotoLibrary: NSObject {
     public private(set) lazy var cachingImageManager = PHCachingImageManager()
     
     /// A reference to all current PHFetchResults.
-    public private(set) lazy var fetchResults = [PhotoLibraryFetchResultDataSource]()
-    
-    /// The assets used in the album.
-    public private(set) var collections = [PhotoLibraryDataSource]() {
-        willSet {
-            guard .authorized == authorizationStatus else {
-                return
-            }
-            
-            cachingImageManager.stopCachingImagesForAllAssets()
-        }
-        
-        didSet {
-            guard .authorized == authorizationStatus else {
-                return
-            }
-            
-            for dataSource in collections {
-                cachingImageManager.startCachingImages(for: dataSource.assets, targetSize: PHImageManagerMaximumSize, contentMode: .aspectFit, options: nil)
-            }
-        }
-    }
+    public private(set) lazy var fetchResultsDataSource = [String: PhotoLibraryFetchResultDataSource]()
     
     /// A reference to a PhotoLibraryDelegate.
     public weak var delegate: PhotoLibraryDelegate?
@@ -221,70 +192,6 @@ public class PhotoLibrary: NSObject {
     public override init() {
         super.init()
         prepare()
-    }
-    
-//    /**
-//     Fetch all the PHAssetCollections asynchronously based on a type and subtype.
-//     - Parameter type: A PHAssetCollectionType.
-//     - Parameter subtype: A PHAssetCollectionSubtype.
-//     - Parameter completion: A completion block.
-//     */
-//    public func fetchAssetCollections(with type: PHAssetCollectionType, subtype: PHAssetCollectionSubtype, completion: ([PhotoLibraryDataSource]) -> Void) {
-//        self.type = type
-//        self.subtype = subtype
-//        
-//        DispatchQueue.global(qos: .default).async { [weak self, type = type, subtype = subtype, completion = completion] in
-//            guard let s = self else {
-//                return
-//            }
-//            
-//            defer {
-//                DispatchQueue.main.async { [weak self] in
-//                    guard let s = self else {
-//                        return
-//                    }
-//                    completion(s.collections)
-//                }
-//            }
-//            
-//            let options = PHFetchOptions()
-//            options.includeHiddenAssets = true
-//            options.includeAllBurstAssets = true
-//            options.wantsIncrementalChangeDetails = true
-//            
-//            s.collectionFetchResult = PHAssetCollection.fetchAssetCollections(with: type, subtype: subtype, options: options)
-//            
-//            s.collectionFetchResult?.enumerateObjects(options: [.concurrent]) { [weak self] (collection, _, _) in
-//                guard let s = self else {
-//                    return
-//                }
-//                
-//                let options = PHFetchOptions()
-//                let descriptor = NSSortDescriptor(key: "creationDate", ascending: false)
-//                options.sortDescriptors = [descriptor]
-//                options.includeHiddenAssets = true
-//                options.includeAllBurstAssets = true
-//                options.wantsIncrementalChangeDetails = true
-//                
-//                s.fetchAssets(in: collection, options: options) { [weak self] (assets, fetchResult) in
-//                    guard let s = self else {
-//                        return
-//                    }
-//                    s.collections.append(PhotoLibraryDataSource(fetchResult: fetchResult, collection: collection, assets: assets))
-//                }
-//            }
-//        }
-//    }
-    
-    /**
-     Performes an asynchronous change to the PHPhotoLibrary database.
-     - Parameter _ block: A transactional block that ensures that
-     all changes to the PHPhotoLibrary are atomic. 
-     - Parameter completion: A completion block that is executed once the
-     transaction has been completed.
-     */
-    public func performChanges(_ block: () -> Void, completion: ((Bool, Error?) -> Void)? = nil) {
-        PHPhotoLibrary.shared().performChanges(block, completionHandler: completion)
     }
     
     /// A method used to prepare the instance object.
@@ -338,6 +245,280 @@ extension PhotoLibrary {
     }
 }
 
+/// Fetch.
+extension PhotoLibrary {
+    /**
+     Fetches generic type T for a given PHFetchResult<T>.
+     - Parameter fetchResult: A PHFetchResult<T>.
+     - Parameter completion: A completion block.
+     */
+    private func fetch<T: PHFetchResult<U>, U: PHObject>(caller: String, result: T, completion: ([U], T) -> Void) {
+        var objects = [U]()
+        
+        result.enumerateObjects({ (collection, _, _) in
+            objects.append(collection)
+        })
+        
+        // Used in change observation.
+        fetchResultsDataSource[caller] = PhotoLibraryFetchResultDataSource(fetchResult: result as! PHFetchResult<PHObject>, objects: objects)
+        
+        if Thread.isMainThread {
+            completion(objects, result)
+        } else {
+            DispatchQueue.main.async { [objects = objects, result = result, completion = completion] in
+                completion(objects, result)
+            }
+        }
+    }
+}
+
+/// PHCollectionList.
+extension PhotoLibrary {
+    /**
+     A PHAssetCollectionTypeMoment collection type will be contained 
+     by a PHCollectionListSubtypeMomentListCluster and a 
+     PHCollectionListSubtypeMomentListYear. Non-moment PHAssetCollections 
+     will only be contained by a single collection list.
+     - Parameter _ collection: A PHCollection.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchCollectionListsContaining(_ collection: PHCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        fetch(caller: #function, result: PHCollectionList.fetchCollectionListsContaining(collection, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch PHCollectionLists based on a type and subtype.
+     - Parameter with type: A PHCollectionListType.
+     - Parameter subtype: A PHCollectionListSubtype.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchCollectionList(with type: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        fetch(caller: #function, result: PHCollectionList.fetchCollectionLists(with: type, subtype: subtype, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch collection lists of a single type matching the 
+     provided local identifiers (type is inferred from the 
+     local identifiers).
+     - Parameter withLocalIdentifier identifiers: An Array 
+     of String identifiers.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchCollectionLists(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        fetch(caller: #function, result: PHCollectionList.fetchCollectionLists(withLocalIdentifiers: identifiers, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch asset collections of a single type and subtype 
+     provided (use PHCollectionListSubtypeAny to match all 
+     subtypes).
+     - Parameter with collectionListType: A PHCollectionListType.
+     - Parameter subtype: A PHCollectionListSubtype.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchCollectionLists(with collectionListType: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        fetch(caller: #function, result: PHCollectionList.fetchCollectionLists(with: collectionListType, subtype: subtype, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch moment lists containing a given moment.
+     - Parameter with momentListSubtype: A PHCollectionListSubtype.
+     - Parameter containingMoment moment: A PHAssetCollection.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, containingMoment moment: PHAssetCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        fetch(caller: #function, result: PHCollectionList.fetchMomentLists(with: momentListSubtype, containingMoment: moment, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch moment lists.
+     - Parameter with momentListSubtype: A PHCollectionListSubtype.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        fetch(caller: #function, result: PHCollectionList.fetchMomentLists(with: momentListSubtype, options: options), completion: completion)
+    }
+}
+
+/// PHCollection.
+extension PhotoLibrary {
+    /**
+     Fetches PHCollections in a given PHCollectionList.
+     - Parameter in collectionList: A PHCollectionList.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchCollections(in collectionList: PHCollectionList, options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
+        fetch(caller: #function, result: PHCollection.fetchCollections(in: collectionList, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches PHCollections based on a type and subtype.
+     - Parameter with type: A PHCollectionListType.
+     - Parameter subtype: A PHCollectionListSubtype.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchTopLevelUserCollections(with options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
+        fetch(caller: #function, result: PHCollection.fetchTopLevelUserCollections(with: nil), completion: completion)
+    }
+}
+
+/// PHAssetCollection.
+extension PhotoLibrary {
+    /**
+     Fetch asset collections of a single type matching the provided 
+     local identifiers (type is inferred from the local identifiers).
+     - Parameter withLocalIdentifiers identifiers: An Array of Strings.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssetCollections(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetch(caller: #function, result: PHAssetCollection.fetchAssetCollections(withLocalIdentifiers: identifiers, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch asset collections of a single type and subtype provided 
+     (use PHAssetCollectionSubtypeAny to match all subtypes).
+     - Parameter with type: A PHAssetCollectionType.
+     - Parameter subtype: A PHAssetCollectionSubtype.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssetCollections(with type: PHAssetCollectionType, subtype: PHAssetCollectionSubtype, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetch(caller: #function, result: PHAssetCollection.fetchAssetCollections(with: type, subtype: subtype, options: options), completion: completion)
+    }
+    
+    /**
+     Smart Albums are not supported, only Albums and Moments.
+     - Parameter asset: A PHAsset.
+     - Parameter with type: A PHAssetCollectionType.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssetCollectionsContaining(_ asset: PHAsset, with type: PHAssetCollectionType, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetch(caller: #function, result: PHAssetCollection.fetchAssetCollectionsContaining(asset, with: type, options: options), completion: completion)
+    }
+    
+    /**
+     AssetGroupURLs are URLs retrieved from ALAssetGroup's 
+     ALAssetsGroupPropertyURL.
+     - Parameter withALAssetGroupURLs assetGroupURLs: An Array 
+     of URLs.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssetCollections(withALAssetGroupURLs assetGroupURLs: [URL], options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetch(caller: #function, result: PHAssetCollection.fetchAssetCollections(withALAssetGroupURLs: assetGroupURLs, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches moments in a given moment list.
+     - Parameter inMomentList momentList: A PHCollectionList.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchMoments(inMomentList momentList: PHCollectionList, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetch(caller: #function, result: PHAssetCollection.fetchMoments(inMomentList: momentList, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches moments.
+     - Parameter with options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchMoments(with options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetch(caller: #function, result: PHAssetCollection.fetchMoments(with: options), completion: completion)
+    }
+}
+
+/// PHAsset.
+extension PhotoLibrary {
+    /**
+     Fetch the PHAssets in a given PHAssetCollection.
+     - Parameter in assetCollection: A PHAssetCollection.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(in assetCollection: PHAssetCollection, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetch(caller: #function, result: PHAsset.fetchAssets(in: assetCollection, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch the PHAssets with a given Array of identifiers.
+     - Parameter withLocalIdentifiers identifiers: A Array of
+     String identifiers.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetch(caller: #function, result: PHAsset.fetchAssets(withLocalIdentifiers: identifiers, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch key assets.
+     - Parameter in assetCollection: A PHAssetCollection.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     - Returns: An optional PHFetchResult<PHAsset> object.
+     */
+    public func fetchKeyAssets(in assetCollection: PHAssetCollection, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) -> PHFetchResult<PHAsset>? {
+        guard let fetchResult = PHAsset.fetchKeyAssets(in: assetCollection, options: options) else {
+            return nil
+        }
+        fetch(caller: #function, result: fetchResult, completion: completion)
+        return fetchResult
+    }
+    
+    /**
+     Fetch a burst asset with a given burst identifier.
+     - Parameter withBurstIdentifier burstIdentifier: A 
+     PHAssetCollection.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(withBurstIdentifier burstIdentifier: String, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetch(caller: #function, result: PHAsset.fetchAssets(withBurstIdentifier: burstIdentifier, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches PHAssetSourceTypeUserLibrary assets by default (use 
+     includeAssetSourceTypes option to override).
+     - Parameter with options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(with options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetch(caller: #function, result: PHAsset.fetchAssets(with: options), completion: completion)
+    }
+    
+    /**
+     Fetch the PHAssets with a given media type.
+     - Parameter in mediaType: A PHAssetMediaType.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(with mediaType: PHAssetMediaType, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetch(caller: #function, result: PHAsset.fetchAssets(with: mediaType, options: options), completion: completion)
+    }
+    
+    /**
+     AssetURLs are URLs retrieved from ALAsset's 
+     ALAssetPropertyAssetURL.
+     - Parameter withALAssetURLs assetURLs: An Array of URLs.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssets(withALAssetURLs assetURLs: [URL], options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
+        fetch(caller: #function, result: PHAsset.fetchAssets(withALAssetURLs: assetURLs, options: options), completion: completion)
+    }
+}
+
 /// PHImageManager.
 extension PhotoLibrary {
     /**
@@ -374,12 +555,12 @@ extension PhotoLibrary {
     }
     
     /**
-     Requests a live photo representation of the asset. With 
-     oportunistic (or if no 
-     options are specified), the resultHandler block may be 
-     called more than once (the first call may occur before 
-     the method returns). The PHImageResultIsDegradedKey key 
-     in the result handler's info parameter indicates when a 
+     Requests a live photo representation of the asset. With
+     oportunistic (or if no
+     options are specified), the resultHandler block may be
+     called more than once (the first call may occur before
+     the method returns). The PHImageResultIsDegradedKey key
+     in the result handler's info parameter indicates when a
      temporary low-quality live photo is provided.
      - Parameter for asset: A PHAsset.
      - Parameter targetSize: A CGSize.
@@ -427,278 +608,6 @@ extension PhotoLibrary {
     }
 }
 
-/// Fetch.
-extension PhotoLibrary {
-    /**
-     Fetches generic type T for a given PHFetchResult<T>.
-     - Parameter fetchResult: A PHFetchResult<T>.
-     - Parameter completion: A completion block.
-     */
-    private func fetch<T: PHFetchResult<U>, U: PHObject>(result: T, completion: ([U], T) -> Void) {
-        var objects = [U]()
-        
-        defer {
-            // Stores for change observation.
-            fetchResults.append(PhotoLibraryFetchResultDataSource(fetchResult: result as! PHFetchResult<PHObject>, objects: objects))
-        }
-        
-        result.enumerateObjects({ (collection, _, _) in
-            objects.append(collection)
-        })
-        
-        DispatchQueue.main.async { [objects = objects, result = result, completion = completion] in
-            completion(objects, result)
-        }
-    }
-}
-
-/// PHCollectionList.
-extension PhotoLibrary {
-    /**
-     A PHAssetCollectionTypeMoment collection type will be contained 
-     by a PHCollectionListSubtypeMomentListCluster and a 
-     PHCollectionListSubtypeMomentListYear. Non-moment PHAssetCollections 
-     will only be contained by a single collection list.
-     - Parameter _ collection: A PHCollection.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchCollectionListsContaining(_ collection: PHCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetch(result: PHCollectionList.fetchCollectionListsContaining(collection, options: options), completion: completion)
-    }
-    
-    /**
-     Fetch PHCollectionLists based on a type and subtype.
-     - Parameter with type: A PHCollectionListType.
-     - Parameter subtype: A PHCollectionListSubtype.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchCollectionList(with type: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetch(result: PHCollectionList.fetchCollectionLists(with: type, subtype: subtype, options: options), completion: completion)
-    }
-    
-    /**
-     Fetch collection lists of a single type matching the 
-     provided local identifiers (type is inferred from the 
-     local identifiers).
-     - Parameter withLocalIdentifier identifiers: An Array 
-     of String identifiers.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchCollectionLists(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetch(result: PHCollectionList.fetchCollectionLists(withLocalIdentifiers: identifiers, options: options), completion: completion)
-    }
-    
-    /**
-     Fetch asset collections of a single type and subtype 
-     provided (use PHCollectionListSubtypeAny to match all 
-     subtypes).
-     - Parameter with collectionListType: A PHCollectionListType.
-     - Parameter subtype: A PHCollectionListSubtype.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchCollectionLists(with collectionListType: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetch(result: PHCollectionList.fetchCollectionLists(with: collectionListType, subtype: subtype, options: options), completion: completion)
-    }
-    
-    /**
-     Fetch moment lists containing a given moment.
-     - Parameter with momentListSubtype: A PHCollectionListSubtype.
-     - Parameter containingMoment moment: A PHAssetCollection.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, containingMoment moment: PHAssetCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetch(result: PHCollectionList.fetchMomentLists(with: momentListSubtype, containingMoment: moment, options: options), completion: completion)
-    }
-    
-    /**
-     Fetch moment lists.
-     - Parameter with momentListSubtype: A PHCollectionListSubtype.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
-        fetch(result: PHCollectionList.fetchMomentLists(with: momentListSubtype, options: options), completion: completion)
-    }
-}
-
-/// PHCollection.
-extension PhotoLibrary {
-    /**
-     Fetches PHCollections in a given PHCollectionList.
-     - Parameter in collectionList: A PHCollectionList.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchCollections(in collectionList: PHCollectionList, options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
-        fetch(result: PHCollection.fetchCollections(in: collectionList, options: options), completion: completion)
-    }
-    
-    /**
-     Fetches PHCollections based on a type and subtype.
-     - Parameter with type: A PHCollectionListType.
-     - Parameter subtype: A PHCollectionListSubtype.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchTopLevelUserCollections(with options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
-        fetch(result: PHCollection.fetchTopLevelUserCollections(with: nil), completion: completion)
-    }
-}
-
-/// PHAssetCollection.
-extension PhotoLibrary {
-    /**
-     Fetch asset collections of a single type matching the provided 
-     local identifiers (type is inferred from the local identifiers).
-     - Parameter withLocalIdentifiers identifiers: An Array of Strings.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssetCollections(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetch(result: PHAssetCollection.fetchAssetCollections(withLocalIdentifiers: identifiers, options: options), completion: completion)
-    }
-    
-    /**
-     Fetch asset collections of a single type and subtype provided 
-     (use PHAssetCollectionSubtypeAny to match all subtypes).
-     - Parameter with type: A PHAssetCollectionType.
-     - Parameter subtype: A PHAssetCollectionSubtype.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssetCollections(with type: PHAssetCollectionType, subtype: PHAssetCollectionSubtype, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetch(result: PHAssetCollection.fetchAssetCollections(with: type, subtype: subtype, options: options), completion: completion)
-    }
-    
-    /**
-     Smart Albums are not supported, only Albums and Moments.
-     - Parameter asset: A PHAsset.
-     - Parameter with type: A PHAssetCollectionType.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssetCollectionsContaining(_ asset: PHAsset, with type: PHAssetCollectionType, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetch(result: PHAssetCollection.fetchAssetCollectionsContaining(asset, with: type, options: options), completion: completion)
-    }
-    
-    /**
-     AssetGroupURLs are URLs retrieved from ALAssetGroup's 
-     ALAssetsGroupPropertyURL.
-     - Parameter withALAssetGroupURLs assetGroupURLs: An Array 
-     of URLs.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssetCollections(withALAssetGroupURLs assetGroupURLs: [URL], options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetch(result: PHAssetCollection.fetchAssetCollections(withALAssetGroupURLs: assetGroupURLs, options: options), completion: completion)
-    }
-    
-    /**
-     Fetches moments in a given moment list.
-     - Parameter inMomentList momentList: A PHCollectionList.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchMoments(inMomentList momentList: PHCollectionList, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetch(result: PHAssetCollection.fetchMoments(inMomentList: momentList, options: options), completion: completion)
-    }
-    
-    /**
-     Fetches moments.
-     - Parameter with options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchMoments(with options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
-        fetch(result: PHAssetCollection.fetchMoments(with: options), completion: completion)
-    }
-}
-
-/// PHAsset.
-extension PhotoLibrary {
-    /**
-     Fetch the PHAssets in a given PHAssetCollection.
-     - Parameter in assetCollection: A PHAssetCollection.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssets(in assetCollection: PHAssetCollection, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetch(result: PHAsset.fetchAssets(in: assetCollection, options: options), completion: completion)
-    }
-    
-    /**
-     Fetch the PHAssets with a given Array of identifiers.
-     - Parameter withLocalIdentifiers identifiers: A Array of
-     String identifiers.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssets(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetch(result: PHAsset.fetchAssets(withLocalIdentifiers: identifiers, options: options), completion: completion)
-    }
-    
-    /**
-     Fetch key assets.
-     - Parameter in assetCollection: A PHAssetCollection.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     - Returns: An optional PHFetchResult<PHAsset> object.
-     */
-    public func fetchKeyAssets(in assetCollection: PHAssetCollection, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) -> PHFetchResult<PHAsset>? {
-        guard let fetchResult = PHAsset.fetchKeyAssets(in: assetCollection, options: options) else {
-            return nil
-        }
-        fetch(result: fetchResult, completion: completion)
-        return fetchResult
-    }
-    
-    /**
-     Fetch a burst asset with a given burst identifier.
-     - Parameter withBurstIdentifier burstIdentifier: A 
-     PHAssetCollection.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssets(withBurstIdentifier burstIdentifier: String, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetch(result: PHAsset.fetchAssets(withBurstIdentifier: burstIdentifier, options: options), completion: completion)
-    }
-    
-    /**
-     Fetches PHAssetSourceTypeUserLibrary assets by default (use 
-     includeAssetSourceTypes option to override).
-     - Parameter with options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssets(with options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetch(result: PHAsset.fetchAssets(with: options), completion: completion)
-    }
-    
-    /**
-     Fetch the PHAssets with a given media type.
-     - Parameter in mediaType: A PHAssetMediaType.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssets(with mediaType: PHAssetMediaType, options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetch(result: PHAsset.fetchAssets(with: mediaType, options: options), completion: completion)
-    }
-    
-    /**
-     AssetURLs are URLs retrieved from ALAsset's 
-     ALAssetPropertyAssetURL.
-     - Parameter withALAssetURLs assetURLs: An Array of URLs.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion block.
-     */
-    public func fetchAssets(withALAssetURLs assetURLs: [URL], options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
-        fetch(result: PHAsset.fetchAssets(withALAssetURLs: assetURLs, options: options), completion: completion)
-    }
-}
-
 /// PHPhotoLibraryChangeObserver extension.
 extension PhotoLibrary: PHPhotoLibraryChangeObserver {
     /**
@@ -707,74 +616,80 @@ extension PhotoLibrary: PHPhotoLibraryChangeObserver {
      photo library.
      */
     public func photoLibraryDidChange(_ changeInfo: PHChange) {
-        for dataSource in fetchResults {
-            print(dataSource)
+        DispatchQueue.main.async { [weak self, changeInfo = changeInfo] in
+            guard let s = self else {
+                return
+            }
+            
+            s.delegate?.photoLibrary?(photoLibrary: s, didChange: changeInfo)
+            
+            for (_, var dataSource) in s.fetchResultsDataSource {
+                for i in 0..<dataSource.objects.count {
+                    let object = dataSource.objects[i]
+                    
+                    guard let details = changeInfo.changeDetails(for: object) else {
+                        continue
+                    }
+                    
+                    guard let afterChanges = details.objectAfterChanges else {
+                        continue
+                    }
+                    
+                    dataSource.objects[i] = afterChanges
+                    
+                    s.delegate?.photoLibrary?(photoLibrary: s, beforeChanges: details.objectBeforeChanges, afterChanges: afterChanges, assetContentChanged: details.assetContentChanged, objectWasDeleted: details.objectWasDeleted)
+                }
+                
+                if let details = changeInfo.changeDetails(for: dataSource.fetchResult as! PHFetchResult<AnyObject>) {
+                    s.delegate?.photoLibrary?(photoLibrary: s, fetchBeforeChanges: details.fetchResultBeforeChanges, fetchAfterChanges: details.fetchResultAfterChanges)
+                    
+                    dataSource.fetchResult = details.fetchResultAfterChanges
+
+                    guard details.hasIncrementalChanges else {
+                        continue
+                    }
+
+                    let removedIndexes = details.removedIndexes
+                    let insertedIndexes = details.insertedIndexes
+                    let changedIndexes = details.changedIndexes
+                
+                    if nil != removedIndexes {
+                        s.delegate?.photoLibrary?(photoLibrary: s, removed: removedIndexes!, for: details.removedObjects)
+                    }
+
+                    if nil != insertedIndexes {
+                        s.delegate?.photoLibrary?(photoLibrary: s, inserted: insertedIndexes!, for: details.insertedObjects)
+                    }
+
+                    if nil != changedIndexes {
+                        s.delegate?.photoLibrary?(photoLibrary: s, changed: changedIndexes!, for: details.changedObjects)
+                    }
+
+                    var moves = [PhotoLibraryMove]()
+
+                    if details.hasMoves {
+                        details.enumerateMoves { (from, to) in
+                            moves.append(PhotoLibraryMove(from: from, to: to))
+                        }
+                    }
+                    
+                    s.delegate?.photoLibrary?(photoLibrary: s, removedIndexes: removedIndexes, insertedIndexes: insertedIndexes, changedIndexes: changedIndexes, has: moves)
+                }
+            }
         }
-        
-//        fetchAssetCollections(with: t, subtype: st) { [weak self, oldCollections = oldCollections] _ in
-//            DispatchQueue.main.async { [weak self, oldCollections = oldCollections] in
-//                guard let s = self else {
-//                    return
-//                }
-//                
-//                // Notify about the general change.
-//                s.delegate?.photoLibrary?(photoLibrary: s, didChange: changeInfo)
-//                
-//                // Notifiy about specific changes.
-//                s.collectionFetchResult?.enumerateObjects(options: .concurrent) { [weak self, changeInfo = changeInfo] (collection, _, _) in
-//                    guard let s = self else {
-//                        return
-//                    }
-//                    
-//                    guard let details = changeInfo.changeDetails(for: collection) else {
-//                        return
-//                    }
-//                    
-//                    guard let afterChanges = details.objectAfterChanges else {
-//                        return
-//                    }
-//                    
-//                    s.delegate?.photoLibrary?(photoLibrary: s, beforeChanges: details.objectBeforeChanges, afterChanges: afterChanges, assetContentChanged: details.assetContentChanged, objectWasDeleted: details.objectWasDeleted)
-//                }
-//                
-//                for i in 0..<oldCollections.count {
-//                    let dataSource = oldCollections[i]
-//                    
-//                    if let details = changeInfo.changeDetails(for: dataSource.fetchResult as! PHFetchResult<AnyObject>) {
-//                        s.delegate?.photoLibrary?(photoLibrary: s, fetchBeforeChanges: details.fetchResultBeforeChanges, fetchAfterChanges: details.fetchResultAfterChanges)
-//                        
-//                        guard details.hasIncrementalChanges else {
-//                            return
-//                        }
-//                        
-//                        let removedIndexes = details.removedIndexes
-//                        let insertedIndexes = details.insertedIndexes
-//                        let changedIndexes = details.changedIndexes
-//                        
-//                        if nil != removedIndexes {
-//                            s.delegate?.photoLibrary?(photoLibrary: s, removed: removedIndexes!, for: details.removedObjects)
-//                        }
-//                        
-//                        if nil != insertedIndexes {
-//                            s.delegate?.photoLibrary?(photoLibrary: s, inserted: insertedIndexes!, for: details.insertedObjects)
-//                        }
-//                        
-//                        if nil != changedIndexes {
-//                            s.delegate?.photoLibrary?(photoLibrary: s, changed: changedIndexes!, for: details.changedObjects)
-//                        }
-//                        
-//                        var moves = [PhotoLibraryMove]()
-//                        
-//                        if details.hasMoves {
-//                            details.enumerateMoves { (from, to) in
-//                                moves.append(PhotoLibraryMove(from: from, to: to))
-//                            }
-//                        }
-//                        
-//                        s.delegate?.photoLibrary?(photoLibrary: s, removedIndexes: removedIndexes, insertedIndexes: insertedIndexes, changedIndexes: changedIndexes, has: moves)
-//                    }
-//                }
-//            }
-//        }
+    }
+}
+
+/// Requesting changes.
+extension PhotoLibrary {
+    /**
+     Performes an asynchronous change to the PHPhotoLibrary database.
+     - Parameter _ block: A transactional block that ensures that
+     all changes to the PHPhotoLibrary are atomic.
+     - Parameter completion: A completion block that is executed once the
+     transaction has been completed.
+     */
+    public func performChanges(_ block: () -> Void, completion: ((Bool, Error?) -> Void)? = nil) {
+        PHPhotoLibrary.shared().performChanges(block, completionHandler: completion)
     }
 }

--- a/Sources/iOS/PhotoLibrary.swift
+++ b/Sources/iOS/PhotoLibrary.swift
@@ -462,6 +462,30 @@ extension PhotoLibrary {
 /// PHCollectionList.
 extension PhotoLibrary {
     /**
+     A PHAssetCollectionTypeMoment collection type will be contained 
+     by a PHCollectionListSubtypeMomentListCluster and a 
+     PHCollectionListSubtypeMomentListYear. Non-moment PHAssetCollections 
+     will only be contained by a single collection list.
+     - Parameter _ collection: A PHCollection.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchCollectionListsContaining(_ collection: PHCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        var lists = [PHCollectionList]()
+        let fetchResult = PHCollectionList.fetchCollectionListsContaining(collection, options: options)
+        
+        defer {
+            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
+                completion(lists, fetchResult)
+            }
+        }
+        
+        fetchResult.enumerateObjects({ (list, _, _) in
+            lists.append(list)
+        })
+    }
+    
+    /**
      Fetch PHCollectionLists based on a type and subtype.
      - Parameter with type: A PHCollectionListType.
      - Parameter subtype: A PHCollectionListSubtype.
@@ -478,9 +502,100 @@ extension PhotoLibrary {
             }
         }
         
-        fetchResult.enumerateObjects(options: [.concurrent]) { (list, _, _) in
+        fetchResult.enumerateObjects({ (list, _, _) in
             lists.append(list)
+        })
+    }
+    
+    /**
+     Fetch collection lists of a single type matching the 
+     provided local identifiers (type is inferred from the 
+     local identifiers).
+     - Parameter withLocalIdentifier identifiers: An Array 
+     of String identifiers.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchCollectionLists(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        var lists = [PHCollectionList]()
+        let fetchResult = PHCollectionList.fetchCollectionLists(withLocalIdentifiers: identifiers, options: options)
+        
+        defer {
+            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
+                completion(lists, fetchResult)
+            }
         }
+        
+        fetchResult.enumerateObjects({ (list, _, _) in
+            lists.append(list)
+        })
+    }
+    
+    /**
+     Fetch asset collections of a single type and subtype 
+     provided (use PHCollectionListSubtypeAny to match all 
+     subtypes).
+     - Parameter with collectionListType: A PHCollectionListType.
+     - Parameter subtype: A PHCollectionListSubtype.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public class func fetchCollectionLists(with collectionListType: PHCollectionListType, subtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        var lists = [PHCollectionList]()
+        let fetchResult = PHCollectionList.fetchCollectionLists(with: collectionListType, subtype: subtype, options: options)
+        
+        defer {
+            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
+                completion(lists, fetchResult)
+            }
+        }
+        
+        fetchResult.enumerateObjects({ (list, _, _) in
+            lists.append(list)
+        })
+    }
+    
+    /**
+     Fetch moment lists containing a given moment.
+     - Parameter with momentListSubtype: A PHCollectionListSubtype.
+     - Parameter containingMoment moment: A PHAssetCollection.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public class func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, containingMoment moment: PHAssetCollection, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        var lists = [PHCollectionList]()
+        let fetchResult = PHCollectionList.fetchMomentLists(with: momentListSubtype, containingMoment: moment, options: options)
+        
+        defer {
+            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
+                completion(lists, fetchResult)
+            }
+        }
+        
+        fetchResult.enumerateObjects({ (list, _, _) in
+            lists.append(list)
+        })
+    }
+    
+    /**
+     Fetch moment lists.
+     - Parameter with momentListSubtype: A PHCollectionListSubtype.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchMomentLists(with momentListSubtype: PHCollectionListSubtype, options: PHFetchOptions?, completion: ([PHCollectionList], PHFetchResult<PHCollectionList>) -> Void) {
+        var lists = [PHCollectionList]()
+        let fetchResult = PHCollectionList.fetchMomentLists(with: momentListSubtype, options: options)
+        
+        defer {
+            DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
+                completion(lists, fetchResult)
+            }
+        }
+        
+        fetchResult.enumerateObjects({ (list, _, _) in
+            lists.append(list)
+        })
     }
 }
 
@@ -504,9 +619,9 @@ extension PhotoLibrary {
         
         fetchResult = PHAsset.fetchAssets(in: assetCollection, options: options)
         
-        fetchResult.enumerateObjects(options: []) { (asset, _, _) in
+        fetchResult.enumerateObjects({ (asset, _, _) in
             assets.append(asset)
-        }
+        })
     }
     
     /**
@@ -527,9 +642,9 @@ extension PhotoLibrary {
         
         fetchResult = PHAsset.fetchAssets(with: mediaType, options: options)
         
-        fetchResult.enumerateObjects(options: []) { (asset, _, _) in
+        fetchResult.enumerateObjects({ (asset, _, _) in
             assets.append(asset)
-        }
+        })
     }
 }
 

--- a/Sources/iOS/PhotoLibrary.swift
+++ b/Sources/iOS/PhotoLibrary.swift
@@ -434,47 +434,6 @@ extension PhotoLibrary {
     }
 }
 
-/// PHCollection.
-extension PhotoLibrary {
-    /**
-     Fetches PHCollections in a given PHCollectionList.
-     - Parameter in collectionList: A PHCollectionList.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchCollections(in collectionList: PHCollectionList, options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
-        fetchCollections(fetchResult: PHCollection.fetchCollections(in: collectionList, options: options), completion: completion)
-    }
-    
-    /**
-     Fetches PHCollections based on a type and subtype.
-     - Parameter with type: A PHCollectionListType.
-     - Parameter subtype: A PHCollectionListSubtype.
-     - Parameter options: An optional PHFetchOptions object.
-     - Parameter completion: A completion callback.
-     */
-    public func fetchTopLevelUserCollections(with options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
-        fetchCollections(fetchResult: PHCollection.fetchTopLevelUserCollections(with: nil), completion: completion)
-    }
-    
-    /**
-     Fetches the PHCollections for a given PHFetchResult<PHCollection>.
-     - Parameter fetchResult: A PHFetchResult<PHCollection>.
-     - Parameter completion: A completion block.
-     */
-    private func fetchCollections(fetchResult: PHFetchResult<PHCollection>, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
-        var collections = [PHCollection]()
-        
-        fetchResult.enumerateObjects({ (collection, _, _) in
-            collections.append(collection)
-        })
-        
-        DispatchQueue.main.async { [collections = collections, fetchResult = fetchResult, completion = completion] in
-            completion(collections, fetchResult)
-        }
-    }
-}
-
 /// PHCollectionList.
 extension PhotoLibrary {
     /**
@@ -549,7 +508,7 @@ extension PhotoLibrary {
     }
     
     /**
-     Fetches the PHCollectionLists for a given PHFetchResult<PHCollectionList>.
+     Fetches PHCollectionLists for a given PHFetchResult<PHCollectionList>.
      - Parameter fetchResult: A PHFetchResult<PHCollectionList>.
      - Parameter completion: A completion block.
      */
@@ -562,6 +521,132 @@ extension PhotoLibrary {
         
         DispatchQueue.main.async { [lists = lists, fetchResult = fetchResult, completion = completion] in
             completion(lists, fetchResult)
+        }
+    }
+}
+
+/// PHCollection.
+extension PhotoLibrary {
+    /**
+     Fetches PHCollections in a given PHCollectionList.
+     - Parameter in collectionList: A PHCollectionList.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchCollections(in collectionList: PHCollectionList, options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
+        fetchCollections(fetchResult: PHCollection.fetchCollections(in: collectionList, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches PHCollections based on a type and subtype.
+     - Parameter with type: A PHCollectionListType.
+     - Parameter subtype: A PHCollectionListSubtype.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion callback.
+     */
+    public func fetchTopLevelUserCollections(with options: PHFetchOptions?, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
+        fetchCollections(fetchResult: PHCollection.fetchTopLevelUserCollections(with: nil), completion: completion)
+    }
+    
+    /**
+     Fetches PHCollections for a given PHFetchResult<PHCollection>.
+     - Parameter fetchResult: A PHFetchResult<PHCollection>.
+     - Parameter completion: A completion block.
+     */
+    private func fetchCollections(fetchResult: PHFetchResult<PHCollection>, completion: ([PHCollection], PHFetchResult<PHCollection>) -> Void) {
+        var collections = [PHCollection]()
+        
+        fetchResult.enumerateObjects({ (collection, _, _) in
+            collections.append(collection)
+        })
+        
+        DispatchQueue.main.async { [collections = collections, fetchResult = fetchResult, completion = completion] in
+            completion(collections, fetchResult)
+        }
+    }
+}
+
+/// PHAssetCollection.
+extension PhotoLibrary {
+    /**
+     Fetch asset collections of a single type matching the provided 
+     local identifiers (type is inferred from the local identifiers).
+     - Parameter withLocalIdentifiers identifiers: An Array of Strings.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssetCollections(withLocalIdentifiers identifiers: [String], options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetchAssetCollections(fetchResult: PHAssetCollection.fetchAssetCollections(withLocalIdentifiers: identifiers, options: options), completion: completion)
+    }
+    
+    /**
+     Fetch asset collections of a single type and subtype provided 
+     (use PHAssetCollectionSubtypeAny to match all subtypes).
+     - Parameter with type: A PHAssetCollectionType.
+     - Parameter subtype: A PHAssetCollectionSubtype.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssetCollections(with type: PHAssetCollectionType, subtype: PHAssetCollectionSubtype, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetchAssetCollections(fetchResult: PHAssetCollection.fetchAssetCollections(with: type, subtype: subtype, options: options), completion: completion)
+    }
+    
+    /**
+     Smart Albums are not supported, only Albums and Moments.
+     - Parameter asset: A PHAsset.
+     - Parameter with type: A PHAssetCollectionType.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssetCollectionsContaining(_ asset: PHAsset, with type: PHAssetCollectionType, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetchAssetCollections(fetchResult: PHAssetCollection.fetchAssetCollectionsContaining(asset, with: type, options: options), completion: completion)
+    }
+    
+    /**
+     AssetGroupURLs are URLs retrieved from ALAssetGroup's 
+     ALAssetsGroupPropertyURL.
+     - Parameter withALAssetGroupURLs assetGroupURLs: An Array 
+     of URLs.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchAssetCollections(withALAssetGroupURLs assetGroupURLs: [URL], options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetchAssetCollections(fetchResult: PHAssetCollection.fetchAssetCollections(withALAssetGroupURLs: assetGroupURLs, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches moments in a given moment list.
+     - Parameter inMomentList momentList: A PHCollectionList.
+     - Parameter options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchMoments(inMomentList momentList: PHCollectionList, options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetchAssetCollections(fetchResult: PHAssetCollection.fetchMoments(inMomentList: momentList, options: options), completion: completion)
+    }
+    
+    /**
+     Fetches moments.
+     - Parameter with options: An optional PHFetchOptions object.
+     - Parameter completion: A completion block.
+     */
+    public func fetchMoments(with options: PHFetchOptions?, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        fetchAssetCollections(fetchResult: PHAssetCollection.fetchMoments(with: options), completion: completion)
+    }
+    
+    /**
+     Fetches PHAssetCollections for a given PHFetchResult<PHAssetCollection>.
+     - Parameter fetchResult: A PHFetchResult<PHAssetCollection>.
+     - Parameter completion: A completion block.
+     */
+    private func fetchAssetCollections(fetchResult: PHFetchResult<PHAssetCollection>, completion: ([PHAssetCollection], PHFetchResult<PHAssetCollection>) -> Void) {
+        var collections = [PHAssetCollection]()
+        
+        fetchResult.enumerateObjects({ (collection, _, _) in
+            collections.append(collection)
+        })
+        
+        DispatchQueue.main.async { [collections = collections, fetchResult = fetchResult, completion = completion] in
+            completion(collections, fetchResult)
         }
     }
 }
@@ -615,7 +700,6 @@ extension PhotoLibrary {
         fetchAssets(fetchResult: PHAsset.fetchAssets(withBurstIdentifier: burstIdentifier, options: options), completion: completion)
     }
     
-    
     /**
      Fetches PHAssetSourceTypeUserLibrary assets by default (use 
      includeAssetSourceTypes option to override).
@@ -625,7 +709,6 @@ extension PhotoLibrary {
     public func fetchAssets(with options: PHFetchOptions?, completion: ([PHAsset], PHFetchResult<PHAsset>) -> Void) {
         fetchAssets(fetchResult: PHAsset.fetchAssets(with: options), completion: completion)
     }
-
     
     /**
      Fetch the PHAssets with a given media type.
@@ -640,7 +723,7 @@ extension PhotoLibrary {
     /**
      AssetURLs are URLs retrieved from ALAsset's 
      ALAssetPropertyAssetURL.
-     - Parameter withALAssetURLs assetURLs: A PHAssetMediaType.
+     - Parameter withALAssetURLs assetURLs: An Array of URLs.
      - Parameter options: An optional PHFetchOptions object.
      - Parameter completion: A completion block.
      */
@@ -649,7 +732,7 @@ extension PhotoLibrary {
     }
     
     /**
-     Fetches the PHAssets for a given PHFetchResult<PHAsset>.
+     Fetches PHAssets for a given PHFetchResult<PHAsset>.
      - Parameter fetchResult: A PHFetchResult<PHAsset>.
      - Parameter completion: A completion block.
      */

--- a/Sources/iOS/PhotoLibraryController.swift
+++ b/Sources/iOS/PhotoLibraryController.swift
@@ -39,15 +39,6 @@ public class PhotoLibraryController: UIViewController, PhotoLibraryDelegate {
         preparePhotoLibrary()
     }
     
-    /**
-     Executes an authorization request with an optional completion block.
-     - Parameter completion: An optional completion block that is executed when
-     authorization status is determined.
-     */
-    public func authorizePhotoLibrary(_ completion: ((PHAuthorizationStatus) -> Void)? = nil) {
-        photoLibrary.requestAuthorization(completion)
-    }
-    
     /// Prepares the photoLibrary.
     private func preparePhotoLibrary() {
         photoLibrary = PhotoLibrary()


### PR DESCRIPTION
The goal of the PhotoLibrary right now is to add a robust and easy to use base library to build whatever PhotoLibrary applications are desired. This PR handles all request types with callbacks and handles PHPhotoLibrary didChange notifications with newly created delegation methods in the Material PhotoLibrary.

I will add the ability to change the PHPhotoLibrary from the Material PhotoLibrary in another PR. 

Part of this PR is already in development as I started work from there. So to view the entire change, please refer to the `PhotoLibrary.swift` file. 