### PR TITLE
Define enumerations for animation

### DIFF
--- a/Sources/iOS/Animation.swift
+++ b/Sources/iOS/Animation.swift
@@ -55,6 +55,35 @@ public func AnimationFillModeToValue(mode: AnimationFillMode) -> String {
 	}
 }
 
+@objc(AnimationTimingFunction)
+public enum AnimationTimingFunction: Int {
+    case liner
+    case easeIn
+    case easeOut
+    case easeInEaseOut
+    case systemDefault
+}
+
+/**
+ Converts the AnimationTimingFunction enum value to a corresponding CAMediaTimingFunction.
+ - Parameter function: An AnimationTimingFunction enum value.
+ */
+public func AnimationTimingFunctionToValue(function: AnimationTimingFunction) -> CAMediaTimingFunction {
+    switch function {
+    case .liner:
+        return CAMediaTimingFunction(name: kCAMediaTimingFunctionLinear)
+    case .easeIn:
+        return CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseIn)
+    case .easeOut:
+        return CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseOut)
+    case .easeInEaseOut:
+        return CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+    case .systemDefault:
+        return CAMediaTimingFunction(name: kCAMediaTimingFunctionDefault)
+    }
+}
+
+
 public typealias AnimationDelayCancelBlock = (Bool) -> Void
 
 public struct Animation {
@@ -106,7 +135,7 @@ public struct Animation {
 		CATransaction.begin()
 		CATransaction.setAnimationDuration(duration)
 		CATransaction.setCompletionBlock(completion)
-		CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut))
+		CATransaction.setAnimationTimingFunction(AnimationTimingFunctionToValue(function: .easeInEaseOut))
 		animations()
 		CATransaction.commit()
 	}
@@ -120,7 +149,7 @@ public struct Animation {
 		group.isRemovedOnCompletion = false
 		group.animations = animations
 		group.duration = duration
-		group.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		group.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		return group
 	}
 	

--- a/Sources/iOS/BasicAnimation.swift
+++ b/Sources/iOS/BasicAnimation.swift
@@ -39,7 +39,7 @@ extension Animation {
 		animation.toValue = color.cgColor
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -54,7 +54,7 @@ extension Animation {
 		animation.toValue = radius
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -69,7 +69,7 @@ extension Animation {
 		animation.toValue = NSValue(caTransform3D: transform)
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -88,7 +88,7 @@ extension Animation {
 		}
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -107,7 +107,7 @@ extension Animation {
 		}
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -126,7 +126,7 @@ extension Animation {
 		}
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -145,7 +145,7 @@ extension Animation {
 		}
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -160,7 +160,7 @@ extension Animation {
 		animation.toValue = scale as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -175,7 +175,7 @@ extension Animation {
 		animation.toValue = scale as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -190,7 +190,7 @@ extension Animation {
 		animation.toValue = scale as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -205,7 +205,7 @@ extension Animation {
 		animation.toValue = scale as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -220,7 +220,7 @@ extension Animation {
 		animation.toValue = NSValue(cgSize: translation)
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -235,7 +235,7 @@ extension Animation {
 		animation.toValue = translation as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
-		animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+		animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -250,7 +250,7 @@ extension Animation {
 		animation.toValue = translation as NSNumber
         animation.fillMode = AnimationFillModeToValue(mode: .forwards)
         animation.isRemovedOnCompletion = false
-        animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+        animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -265,7 +265,7 @@ extension Animation {
 		animation.toValue = translation as NSNumber
         animation.fillMode = AnimationFillModeToValue(mode: .forwards)
         animation.isRemovedOnCompletion = false
-        animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+        animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -280,7 +280,7 @@ extension Animation {
 		animation.toValue = NSValue(cgPoint: point)
         animation.fillMode = AnimationFillModeToValue(mode: .forwards)
         animation.isRemovedOnCompletion = false
-        animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+        animation.timingFunction = AnimationTimingFunctionToValue(function: .easeInEaseOut)
 		if let v = duration {
 			animation.duration = v
 		}
@@ -292,7 +292,7 @@ extension Animation {
 		animation.toValue = path
         animation.fillMode = AnimationFillModeToValue(mode: .forwards)
         animation.isRemovedOnCompletion = false
-        animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionLinear)
+        animation.timingFunction = AnimationTimingFunctionToValue(function: .liner)
 		if let v = duration {
 			animation.duration = v
 		}

--- a/Sources/iOS/BasicAnimation.swift
+++ b/Sources/iOS/BasicAnimation.swift
@@ -30,12 +30,38 @@
 
 import UIKit
 
+public enum AnimationKey: String {
+    case backgroundColor
+    case cornerRadius
+    case transform
+    case transformRotation  = "transform.rotation"
+    case transformRotationX = "transform.rotation.x"
+    case transformRotationY = "transform.rotation.y"
+    case transformRotationZ = "transform.rotation.z"
+    case transformScale  = "transform.scale"
+    case transformScaleX = "transform.scale.x"
+    case transformScaleY = "transform.scale.y"
+    case transformScaleZ = "transform.scale.z"
+    case transformTranslation  = "transform.translation"
+    case transformTranslationX = "transform.translation.x"
+    case transformTranslationY = "transform.translation.y"
+    case transformTranslationZ = "transform.translation.z"
+    case position
+    case shadowPath
+}
+
+extension CABasicAnimation {
+    convenience init(keyPath key: AnimationKey) {
+        self.init(keyPath: key.rawValue)
+    }
+}
+
 extension Animation {
 	/**
 	:name:	backgroundColor
 	*/
 	public static func backgroundColor(color: UIColor, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "backgroundColor")
+		let animation = CABasicAnimation(keyPath: .backgroundColor)
 		animation.toValue = color.cgColor
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
@@ -50,7 +76,7 @@ extension Animation {
 	:name:	cornerRadius
 	*/
 	public static func cornerRadius(radius: CGFloat, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "cornerRadius")
+		let animation = CABasicAnimation(keyPath: .cornerRadius)
 		animation.toValue = radius
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
@@ -65,7 +91,7 @@ extension Animation {
 	:name:	translation
 	*/
 	public static func transform(transform: CATransform3D, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform")
+		let animation = CABasicAnimation(keyPath: .transform)
 		animation.toValue = NSValue(caTransform3D: transform)
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
@@ -80,7 +106,7 @@ extension Animation {
 	:name:	rotate
 	*/
 	public static func rotate(angle: CGFloat? = nil, rotation: CGFloat? = nil, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.rotation")
+		let animation = CABasicAnimation(keyPath: .transformRotation)
 		if let v: CGFloat = angle {
 			animation.toValue = (CGFloat(M_PI) * v / 180) as NSNumber
 		} else if let v: CGFloat = rotation {
@@ -99,7 +125,7 @@ extension Animation {
 	:name:	rotateX
 	*/
 	public static func rotateX(angle: CGFloat? = nil, rotation: CGFloat? = nil, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.rotation.x")
+		let animation = CABasicAnimation(keyPath: .transformRotationX)
 		if let v: CGFloat = angle {
 			animation.toValue = (CGFloat(M_PI) * v / 180) as NSNumber
 		} else if let v: CGFloat = rotation {
@@ -118,7 +144,7 @@ extension Animation {
 	:name:	rotateY
 	*/
 	public static func rotateY(angle: CGFloat? = nil, rotation: CGFloat? = nil, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.rotation.y")
+		let animation = CABasicAnimation(keyPath: .transformRotationY)
 		if let v: CGFloat = angle {
 			animation.toValue = (CGFloat(M_PI) * v / 180) as NSNumber
 		} else if let v: CGFloat = rotation {
@@ -137,7 +163,7 @@ extension Animation {
 	:name:	rotateZ
 	*/
 	public static func rotateZ(angle: CGFloat? = nil, rotation: CGFloat? = nil, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.rotation.z")
+		let animation = CABasicAnimation(keyPath: .transformRotationZ)
 		if let v: CGFloat = angle {
 			animation.toValue = (CGFloat(M_PI) * v / 180) as NSNumber
 		} else if let v: CGFloat = rotation {
@@ -156,7 +182,7 @@ extension Animation {
 	:name:	scale
 	*/
 	public static func scale(scale: CGFloat, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.scale")
+		let animation = CABasicAnimation(keyPath: .transformScale)
 		animation.toValue = scale as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
@@ -171,7 +197,7 @@ extension Animation {
 	:name:	scaleX
 	*/
 	public static func scaleX(scale: CGFloat, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.scale.x")
+		let animation = CABasicAnimation(keyPath: .transformScaleX)
 		animation.toValue = scale as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
@@ -186,7 +212,7 @@ extension Animation {
 	:name:	scaleY
 	*/
 	public static func scaleY(scale: CGFloat, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.scale.y")
+		let animation = CABasicAnimation(keyPath: .transformScaleY)
 		animation.toValue = scale as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
@@ -201,7 +227,7 @@ extension Animation {
 	:name:	scaleZ
 	*/
 	public static func scaleZ(scale: CGFloat, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.scale.z")
+		let animation = CABasicAnimation(keyPath: .transformScaleZ)
 		animation.toValue = scale as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
@@ -216,7 +242,7 @@ extension Animation {
 	:name:	translate
 	*/
 	public static func translate(translation: CGSize, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.translation")
+		let animation = CABasicAnimation(keyPath: .transformTranslation)
 		animation.toValue = NSValue(cgSize: translation)
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
@@ -231,7 +257,7 @@ extension Animation {
 	:name:	translateX
 	*/
 	public static func translateX(translation: CGFloat, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.translation.x")
+		let animation = CABasicAnimation(keyPath: .transformTranslationX)
 		animation.toValue = translation as NSNumber
 		animation.fillMode = AnimationFillModeToValue(mode: .forwards)
 		animation.isRemovedOnCompletion = false
@@ -246,7 +272,7 @@ extension Animation {
 	:name:	translateY
 	*/
 	public static func translateY(translation: CGFloat, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.translation.y")
+		let animation = CABasicAnimation(keyPath: .transformTranslationY)
 		animation.toValue = translation as NSNumber
         animation.fillMode = AnimationFillModeToValue(mode: .forwards)
         animation.isRemovedOnCompletion = false
@@ -261,7 +287,7 @@ extension Animation {
 	:name:	translateZ
 	*/
 	public static func translateZ(translation: CGFloat, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "transform.translation.z")
+		let animation = CABasicAnimation(keyPath: .transformTranslationZ)
 		animation.toValue = translation as NSNumber
         animation.fillMode = AnimationFillModeToValue(mode: .forwards)
         animation.isRemovedOnCompletion = false
@@ -276,7 +302,7 @@ extension Animation {
 	:name:	position
 	*/
 	public static func position(point: CGPoint, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "position")
+		let animation = CABasicAnimation(keyPath: .position)
 		animation.toValue = NSValue(cgPoint: point)
         animation.fillMode = AnimationFillModeToValue(mode: .forwards)
         animation.isRemovedOnCompletion = false
@@ -288,7 +314,7 @@ extension Animation {
 	}
 	
 	public static func shadowPath(path: CGPath, duration: CFTimeInterval? = nil) -> CABasicAnimation {
-		let animation = CABasicAnimation(keyPath: "shadowPath")
+		let animation = CABasicAnimation(keyPath: .shadowPath)
 		animation.toValue = path
         animation.fillMode = AnimationFillModeToValue(mode: .forwards)
         animation.isRemovedOnCompletion = false

--- a/Sources/iOS/KeyframeAnimation.swift
+++ b/Sources/iOS/KeyframeAnimation.swift
@@ -57,7 +57,7 @@ extension Animation {
 	*/
 	public static func path(bezierPath: UIBezierPath, mode: AnimationRotationMode = .auto, duration: CFTimeInterval? = nil) -> CAKeyframeAnimation {
 		let animation: CAKeyframeAnimation = CAKeyframeAnimation()
-		animation.keyPath = "position"
+		animation.keyPath = AnimationKey.position.rawValue
 		animation.path = bezierPath.cgPath
         animation.rotationMode = AnimationRotationModeToValue(mode: mode)
 		if let v = duration {


### PR DESCRIPTION
Hi :smiley:
I define 2 enumeration for animation.

### `AnimationTimingFunction`
`kCA-prefix` isn't suitable for Swift-Style.
so I define `AnimationTimingFunction`. please use `AnimationTimingFunctionToValue()` with `AnimationTimingFunction` like as `AnimationFillModeToValue()`.

### `AnimationKey`
I define `convenience initializer` with `AnimationKey` in `CABasicAnimation`.
enabled to initialize very easily, safely. 