### PR TITLE
Fix Xcode 8 issue with `NavigationDrawerController` conforming to `UIGestureRecognizerDelegate`

### DIFF
--- a/Sources/iOS/NavigationDrawerController.swift
+++ b/Sources/iOS/NavigationDrawerController.swift
@@ -143,7 +143,7 @@ public protocol NavigationDrawerControllerDelegate {
 }
 
 @objc(NavigationDrawerController)
-open class NavigationDrawerController: RootController, UIGestureRecognizerDelegate {
+open class NavigationDrawerController: RootController {
 	/**
      A CGFloat property that is used internally to track
      the original (x) position of the container view when panning.
@@ -1075,7 +1075,7 @@ extension NavigationDrawerController {
     }
 }
 
-extension NavigationDrawerController {
+extension NavigationDrawerController: UIGestureRecognizerDelegate {
     /**
      Detects the gesture recognizer being used.
      - Parameter gestureRecognizer: A UIGestureRecognizer to detect.


### PR DESCRIPTION
Xcode Version 8.0 (8A218a) was getting confused about `NavigationController` adopting `UIGestureRecognizerDelegate` in an extension when protocol conformance was declared on the class itself. 

This resulted in a compiler error saying the `gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool` signature didn't match the protocol signature (when it actually does).

Declaring the `extension` as conforming to `UIGestureRecognizerDelegate` instead of the class seems to help Xcode 8 figure this out and resolves the compiler error.