### PR TITLE
fix animation of PageTabBar Line on scroll

### DIFF
--- a/Sources/iOS/PageTabBarController.swift
+++ b/Sources/iOS/PageTabBarController.swift
@@ -377,7 +377,7 @@ extension PageTabBarController: UIScrollViewDelegate {
             return
         }
         
-        let x = (scrollView.contentOffset.x - view.width) / scrollView.contentSize.width * view.width
+        let x = (scrollView.contentOffset.x - view.width) / CGFloat(viewControllers.count)
         
         pageTabBar.line.center.x = selected.center.x + x
     }


### PR DESCRIPTION
this fix #768 , I think it would be better using `viewControllers.count` instead of calculating it again. Because `scrollView.contentSize.width / view.width` not working properly especially after three child controllers.