### PR TITLE
Add convenience property for the attributed text of the snackbar label

### DIFF
--- a/Sources/iOS/Snackbar.swift
+++ b/Sources/iOS/Snackbar.swift
@@ -48,6 +48,17 @@ open class Snackbar: Bar {
         }
     }
     
+    /// A convenience property to set the titleLabel attributedText.
+    open var attributedText: NSAttributedString? {
+        get {
+            return textLabel.attributedText
+        }
+        set(value) {
+            textLabel.attributedText = value
+            layoutSubviews()
+        }
+    }
+    
     /// Text label.
     @IBInspectable
     open let textLabel = UILabel()


### PR DESCRIPTION
This will allow for developers to access the attributedText property of the UILabel of the snackbar and let us set inline images if so desired