### PR TITLE
Fixed TabBar line position when animating after scroll

### DIFF
--- a/Sources/iOS/TabBar.swift
+++ b/Sources/iOS/TabBar.swift
@@ -423,8 +423,8 @@ extension TabBar {
                 return
             }
             
-            s.line.center.x = button.center.x
             s.line.width = button.width
+            s.line.center.x = button.center.x
             
             if !s.scrollView.bounds.contains(button.frame) {
                 let contentOffsetX = (button.x < s.scrollView.bounds.minX) ? button.x : button.frame.maxX - s.scrollView.bounds.width


### PR DESCRIPTION
This is fix for [#811](https://github.com/CosmicMind/Material/issues/811). The problem was that when you assign `center` and `width` to the `line`, you set `center` first and `width` later, which resulted in incorrect position because the `center` of `line` changed after changing `width`.

I know, that the scrollable `TabBar` was removed because it's not finished yet, but I'd like to have the feature in my project even if it's experimental. Maybe I'll help with further debugging 🙂 