### PR TITLE
Add placeholderHorizinalOffset attribute

### DIFF
--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -212,6 +212,10 @@ open class TextField: UITextField {
 	/// This property adds a padding to placeholder y position animation
 	@IBInspectable
     open var placeholderVerticalOffset: CGFloat = 0
+    
+    /// This property adds a padding to placeholder y position animation
+    @IBInspectable
+    open var placeholderHorizinalOffset: CGFloat = 0
 	
 	/// The detailLabel UILabel that is displayed.
 	@IBInspectable
@@ -505,9 +509,9 @@ fileprivate extension TextField {
         
         switch textAlignment {
         case .left, .natural:
-            placeholderLabel.x = w
+            placeholderLabel.x = w + placeholderHorizinalOffset
         case .right:
-            placeholderLabel.x = width - placeholderLabel.width - textInset
+            placeholderLabel.x = width - placeholderLabel.width - textInset + placeholderHorizinalOffset
         default:break
         }
         
@@ -642,9 +646,9 @@ extension TextField {
             
             switch s.textAlignment {
             case .left, .natural:
-                s.placeholderLabel.x = s.leftViewWidth + s.textInset
+                s.placeholderLabel.x = s.leftViewWidth + s.textInset + s.placeholderHorizinalOffset
             case .right:
-                s.placeholderLabel.x = s.width - s.placeholderLabel.width - s.textInset
+                s.placeholderLabel.x = s.width - s.placeholderLabel.width - s.textInset + s.placeholderHorizinalOffset
             default:break
             }
             


### PR DESCRIPTION
On TextField, my customer wants the placeholder text jump right above the icon. We had placeholderVerticalOffset which modify the y position of placeholder when animate. Then we may need placeholderHorizinalOffset to modify the x position of placeholder also
 
![un_focus](https://user-images.githubusercontent.com/13307878/29993648-59f6bada-8fe7-11e7-94be-1d6e6c988c4c.png)
![focus](https://user-images.githubusercontent.com/13307878/29993649-59ff8138-8fe7-11e7-964c-e9cd1c48b567.png)

