### PR TITLE
Fixes PlaceholderLabel position when right-aligned - iOS 11.0

### DIFF
--- a/Sources/iOS/Base.swift
+++ b/Sources/iOS/Base.swift
@@ -33,7 +33,8 @@ class Base: UIControl {
         beforeSecondAnimation()
         secondAnimation()
     }
-    
+
+    @objc
     func didTap() {
         self.isSelected = !self.isSelected
         self.animate()

--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -566,7 +566,7 @@ fileprivate extension TextField {
         case .left, .natural:
             placeholderLabel.frame.origin.x = w + placeholderHorizontalOffset
         case .right:
-            placeholderLabel.frame.origin.x = (s.bounds.width * (1.0 - s.placeholderActiveScale)) - textInset + placeholderHorizontalOffset
+            placeholderLabel.frame.origin.x = (bounds.width * (1.0 - placeholderActiveScale)) - textInset + placeholderHorizontalOffset
         default:break
         }
         
@@ -707,7 +707,7 @@ extension TextField {
             case .left, .natural:
                 s.placeholderLabel.frame.origin.x = s.leftViewWidth + s.textInset + s.placeholderHorizontalOffset
             case .right:
-                s.placeholderLabel.frame.origin.x = s.bounds.width - s.placeholderLabel.bounds.width - s.textInset + s.placeholderHorizontalOffset
+                s.placeholderLabel.frame.origin.x = (s.bounds.width * (1.0 - s.placeholderActiveScale)) - s.textInset + s.placeholderHorizontalOffset
             default:break
             }
             

--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -566,7 +566,7 @@ fileprivate extension TextField {
         case .left, .natural:
             placeholderLabel.frame.origin.x = w + placeholderHorizontalOffset
         case .right:
-            placeholderLabel.frame.origin.x = bounds.width - placeholderLabel.bounds.width - textInset + placeholderHorizontalOffset
+            placeholderLabel.frame.origin.x = bounds.width - placeholderLabel.frame.width - textInset + placeholderHorizontalOffset
         default:break
         }
         

--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -566,7 +566,7 @@ fileprivate extension TextField {
         case .left, .natural:
             placeholderLabel.frame.origin.x = w + placeholderHorizontalOffset
         case .right:
-            placeholderLabel.frame.origin.x = bounds.width - placeholderLabel.frame.width - textInset + placeholderHorizontalOffset
+            placeholderLabel.frame.origin.x = (s.bounds.width * (1.0 - s.placeholderActiveScale)) - textInset + placeholderHorizontalOffset
         default:break
         }
         


### PR DESCRIPTION
Hi,
It seems like UIKit doesn't apply transform to a view's `bounds` anymore, therefore, the line of code that determines `placeholderLabel`'s position results in zero difference between the original frame and scaled down `placeholderLabel`'s. (`TextField.swift` line: 569)


The solution is to use `placehlderLabel`'s `frame` instead.
