### PR TITLE
Introducing tabBarItemsNormalColor and tabBarItemsSelectedColor

### DIFF
--- a/Sources/iOS/Button.swift
+++ b/Sources/iOS/Button.swift
@@ -131,6 +131,14 @@ open class Button: UIButton, Pulseable, PulseableLayer {
             setTitleColor(titleColor, for: .highlighted)
         }
     }
+
+    /// Sets the selected titleColor for the button.
+    @IBInspectable
+    open var selectedTitleColor: UIColor? {
+        didSet {
+            setTitleColor(selectedTitleColor, for: .selected)
+        }
+    }
     
 	/**
      An initializer that initializes the object with a NSCoder object.

--- a/Sources/iOS/TabBar.swift
+++ b/Sources/iOS/TabBar.swift
@@ -202,18 +202,11 @@ open class TabBar: Bar {
         }
     }
 
-    /// Tab bars normal title color.
-    open var tabItemsNormalTitleColor: UIColor? {
-        didSet {
+    /// TabBar items normal title color.
+    open var tabItemsNormalTitleColor: UIColor?
 
-        }
-    }
-
-    open var tabItemsSelectedTitleColor: UIColor? {
-        didSet {
-
-        }
-    }
+    /// TabBar items selected title color.
+    open var tabItemsSelectedTitleColor: UIColor?
 
     /// A reference to the line UIView.
     open let line = UIView()

--- a/Sources/iOS/TabBar.swift
+++ b/Sources/iOS/TabBar.swift
@@ -139,7 +139,14 @@ open class TabBar: Bar {
     internal weak var _delegate: _TabBarDelegate?
     
     /// The currently selected tabItem.
-    open internal(set) var selectedTabItem: TabItem?
+    open internal(set) var selectedTabItem: TabItem? {
+        willSet {
+            selectedTabItem?.isSelected = false
+        }
+        didSet {
+            selectedTabItem?.isSelected = true
+        }
+    }
     
     /// A preset wrapper around tabItems contentEdgeInsets.
     open var tabItemsContentEdgeInsetsPreset: EdgeInsetsPreset {
@@ -194,7 +201,20 @@ open class TabBar: Bar {
             layoutSubviews()
         }
     }
-    
+
+    /// Tab bars normal title color.
+    open var tabItemsNormalTitleColor: UIColor? {
+        didSet {
+
+        }
+    }
+
+    open var tabItemsSelectedTitleColor: UIColor? {
+        didSet {
+
+        }
+    }
+
     /// A reference to the line UIView.
     open let line = UIView()
     
@@ -272,7 +292,9 @@ fileprivate extension TabBar {
         for v in tabItems {
             v.grid.columns = 0
             v.contentEdgeInsets = .zero
-            
+            if Color.blue.base == v.titleColor  { v.titleColor = tabItemsNormalTitleColor }
+            if nil == v.selectedTitleColor { v.selectedTitleColor = tabItemsSelectedTitleColor }
+
             prepareLineAnimationHandler(tabItem: v)
         }
         


### PR DESCRIPTION
This PR helps to achieve goals defined in #860.
To be able to do so, I have introduced a new helper variable on `Button` named `selectedTitleColor`

You can now set colors for normal and selected state of all tabBar items on a `TabBar` using `tabBarItemsNormalTitleColor` and `tabBarItemsSelectedTitleColor`.

These colors won't be applied on a `TabItem` with custom colors set for its `titleColor` and `selectedTitleColor`.
