### PR TITLE
Tab bar controller dynamically adds & removes child view controllers

### DIFF
--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -197,12 +197,14 @@ fileprivate extension TabsController {
             return
         }
         
-        let tvc = viewController
-        tvc.view.isHidden = false
-        tvc.view.frame = container.bounds
-        
         let fvcIndex = viewControllers.index(of: fvc)
         let tvcIndex = viewControllers.index(of: viewController)
+        
+        let tvc = viewController
+        tvc.beginAppearanceTransition(true, animated: true)
+        prepareViewController(at: tvcIndex!)
+        tvc.view.isHidden = false
+        tvc.view.frame = container.bounds
         
         var isAuto = false
         
@@ -229,6 +231,9 @@ fileprivate extension TabsController {
             
             s.rootViewController = tvc
             s.view.isUserInteractionEnabled = true
+            tvc.endAppearanceTransition()
+            
+            s.removeViewController(viewController: fvc)
             
             completion?(isFinished)
             

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -249,15 +249,6 @@ internal extension TabsController {
 fileprivate extension TabsController {
     /// Prepares all the view controllers.
     func prepareViewControllers() {
-        for i in 0..<viewControllers.count {
-            guard i != selectedIndex else {
-                continue
-            }
-            
-            viewControllers[i].view.isHidden = true
-            prepareViewController(at: i)
-        }
-        
         prepareViewController(at: selectedIndex)
         prepareRootViewController()
     }


### PR DESCRIPTION
This is one solution for #919 where by the tabs controllers are only added to the child view controller stack upon requested transitioning. 
