### PR TITLE
Tab bar controller dynamically adds & removes child view controllers

### DIFF
--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -286,6 +286,12 @@ fileprivate extension TabsController {
         var tabItems = [TabItem]()
         
         for v in viewControllers {
+            // Expectation that viewDidLoad() triggers update of tab item title:
+            if #available(iOS 9.0, *) {
+                v.loadViewIfNeeded()
+            } else {
+                _ = v.view
+            }
             tabItems.append(v.tabItem)
         }
         

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -197,6 +197,8 @@ fileprivate extension TabsController {
             return
         }
         
+        fvc.beginAppearanceTransition(false, animated: true)
+        
         let fvcIndex = viewControllers.index(of: fvc)
         let tvcIndex = viewControllers.index(of: viewController)
         
@@ -234,6 +236,7 @@ fileprivate extension TabsController {
             tvc.endAppearanceTransition()
             
             s.removeViewController(viewController: fvc)
+            fvc.endAppearanceTransition()
             
             completion?(isFinished)
             


### PR DESCRIPTION
This is one solution for #919 where by the tabs controllers are only added to the child view controller stack upon requested transitioning.
#920