### PR TITLE
Missing calls to TabsController destination transition

### DIFF
--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -223,6 +223,10 @@ fileprivate extension TabsController {
         view.isUserInteractionEnabled = false
         
         fvc.beginAppearanceTransition(false, animated: true)
+        tvc.beginAppearanceTransition(true, animated: true)
+        
+        // Adds the view controller as a child:
+        prepareViewController(at: tvcIndex)
         
         Motion.shared.transition(from: fvc, to: viewController, in: container) { [weak self, tvc = tvc, isAuto = isAuto, completion = completion] (isFinished) in
             guard let s = self else {
@@ -239,6 +243,7 @@ fileprivate extension TabsController {
             s.removeViewController(viewController: fvc)
             
             fvc.endAppearanceTransition()
+            tvc.endAppearanceTransition()
             
             completion?(isFinished)
 


### PR DESCRIPTION
As explained in #935 there is a line missing from `TabsController` which appropriately adds the destination view controller as a child before performing the transition. This has been removed during commit: 11430ef1c8bb5be1566aa1cf56c5bf1720bbb31c
 
What's also required is the appropriate transition calls on the destination view controller, without these the view controller lifetime functions are called more times than necessary due to Motion adding the destination view controller view to the transition context. 