### PR TITLE
TabsController - Missing logic

### DIFF
--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -170,6 +170,10 @@ open class TabsController: TransitionController {
         layoutRootViewController()
     }
     
+    open override var shouldAutomaticallyForwardAppearanceMethods: Bool {
+        return false
+    }
+    
     open override func prepare() {
         super.prepare()
         view.backgroundColor = .white
@@ -222,9 +226,6 @@ fileprivate extension TabsController {
         
         view.isUserInteractionEnabled = false
         
-        fvc.beginAppearanceTransition(false, animated: true)
-        tvc.beginAppearanceTransition(true, animated: true)
-        
         // Adds the view controller as a child:
         prepareViewController(at: tvcIndex)
         
@@ -242,8 +243,6 @@ fileprivate extension TabsController {
             
             s.removeViewController(viewController: fvc)
             
-            fvc.endAppearanceTransition()
-            tvc.endAppearanceTransition()
             completion?(isFinished)
 
             if isTriggeredByUserInteraction {

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -222,6 +222,12 @@ fileprivate extension TabsController {
         
         view.isUserInteractionEnabled = false
         
+        fvc.beginAppearanceTransition(false, animated: true)
+        tvc.beginAppearanceTransition(true, animated: true)
+        
+        // Adds the view controller as a child:
+        prepareViewController(at: tvcIndex)
+        
         Motion.shared.transition(from: fvc, to: viewController, in: container) { [weak self, tvc = tvc, isAuto = isAuto, completion = completion] (isFinished) in
             guard let s = self else {
                 return
@@ -236,6 +242,8 @@ fileprivate extension TabsController {
             
             s.removeViewController(viewController: fvc)
             
+            fvc.endAppearanceTransition()
+            tvc.endAppearanceTransition()
             completion?(isFinished)
 
             if isTriggeredByUserInteraction {


### PR DESCRIPTION
As outlined in #935 and provided fix in #936.

Here is a PR again which provides the appropriate logic for adding the destination view controller to the child view controller stack & calls the appropriate appearance transitions in the correct order. 
