### PR TITLE
Allow tabItem to be overwritten

### DIFF
--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -41,7 +41,7 @@ public enum TabBarAlignment: Int {
 
 extension UIViewController {
     /// tabItem reference.
-    public private(set) var tabItem: TabItem {
+    @objc open private(set) var tabItem: TabItem {
         get {
             return AssociatedObject.get(base: self, key: &TabItemKey) {
                 return TabItem()


### PR DESCRIPTION
In my scenario in using TabsController - each ViewController is actually a `UINavigationController`. Because `TabsController` extends `UIViewController` in order to setup the tabs - in `prepareTabItems` it is checking for `tabItem` inside whatever the viewController is. 

In my case, it's trying to check the `UINavigationController` for `tabItem` which isn't setup, because it's being setup in the rootViewController of that navigationController.

This PR allow me to create subclassed UINavigationController, which sets the `tabItem` to be rootViewControllers tabItem property. Ex:

```
class CustomNavController: UINavigationController {
    override var tabItem: TabItem {
        guard let vc = viewControllers.first else {
            assert(true, "Nav Controllers must have at least one viewController")
            return TabItem()
        }
        return vc.tabItem
    }
}
```

So this allows me to setup the tabItem inside each ViewController that is the root. 

If there's a better way to do this, I'm open to suggestions. 