### PR TITLE
Announce an ErrorTextField's error on VoiceOver when shown. [Accessibility]

### DIFF
--- a/Sources/iOS/ErrorTextField.swift
+++ b/Sources/iOS/ErrorTextField.swift
@@ -37,9 +37,14 @@ open class ErrorTextField: TextField {
         didSet {
             detailLabel.isHidden = !isErrorRevealed
             layoutSubviews()
+
+            if let detail = detailLabel.text, isErrorRevealed {
+              // Announce what is happening to VoiceOver users
+              UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, detail)
+            }
         }
     }
-    
+
     open override func prepare() {
         super.prepare()
         isErrorRevealed = false


### PR DESCRIPTION
when isErrorRevealed is set to true, and there is detail text, then announce it on voiceOver.