### PR TITLE
Document material color codes

### DIFF
--- a/Sources/iOS/Color.swift
+++ b/Sources/iOS/Color.swift
@@ -32,26 +32,40 @@ import UIKit
 
 @objc(ColorPalette)
 public protocol ColorPalette {
+  /// Material color code: 50
   static var lighten5: UIColor { get }
+  /// Material color code: 100
   static var lighten4: UIColor { get }
+  /// Material color code: 200
   static var lighten3: UIColor { get }
+  /// Material color code: 300
   static var lighten2: UIColor { get }
+  /// Material color code: 400
   static var lighten1: UIColor { get }
+  /// Material color code: 500
   static var base: UIColor { get }
+  /// Material color code: 600
   static var darken1: UIColor { get }
+  /// Material color code: 700
   static var darken2: UIColor { get }
+  /// Material color code: 800
   static var darken3: UIColor { get }
+  /// Material color code: 900
   static var darken4: UIColor { get }
   
+  /// Material color code: A100
   @objc
   optional static var accent1: UIColor { get }
   
+  /// Material color code: A200
   @objc
   optional static var accent2: UIColor { get }
   
+  /// Material color code: A400
   @objc
   optional static var accent3: UIColor { get }
   
+  /// Material color code: A700
   @objc
   optional static var accent4: UIColor { get }
 }


### PR DESCRIPTION
Adds documentation as requested in #1000. 
<img width="544" alt="screen shot 2018-03-15 at 10 55 58" src="https://user-images.githubusercontent.com/2232699/37453204-a6a15070-283f-11e8-9c7b-29d192e8eb76.png">
