### PR TITLE
Open up FABMenu a little bit

### DIFF
--- a/Sources/iOS/FABMenu.swift
+++ b/Sources/iOS/FABMenu.swift
@@ -186,7 +186,7 @@ open class FABMenu: View {
   
   
   /// A reference to the SpringAnimation object.
-  internal let spring = SpringAnimation()
+  let spring = SpringAnimation()
   
   open var fabMenuDirection: FABMenuDirection {
     get {

--- a/Sources/iOS/FABMenuController.swift
+++ b/Sources/iOS/FABMenuController.swift
@@ -50,7 +50,7 @@ extension UIViewController {
 open class FABMenuController: TransitionController {
   /// Reference to the MenuView.
   @IBInspectable
-  open let fabMenu = FABMenu()
+  open var fabMenu = FABMenu()
   
   /// A FABMenuBacking value type.
   open var fabMenuBacking = FABMenuBacking.blur


### PR DESCRIPTION
Hi,

I'm using the `FABMenu` and `FABMenuController` to create a more custom layout, however currently a few properties are internal or let's that not allowing me to subclass/modify.

1. By removing the `internal` from the `SpringAnimation` on the FABMenu, that allows my subclass to have access to the spring variable.

2. By changing `fabMenu` on `FabMenuController` to a var - it allows me to update that to be a subclass, so I can override layouts and such.

My main issue that I was trying to solve, was the springAnimation.reload, was always drawing the buttons in the center. I am wanting a right aligned button. These changes allow me (by subclassing and overriding) to do:

<img width="316" alt="screenshot 2018-04-17 09 07 24" src="https://user-images.githubusercontent.com/1119565/38874875-c3f30d28-421e-11e8-9622-a0953272291a.png">
