### PR TITLE
Added custom navigationBarClass support to NavigationController

### DIFF
--- a/Sources/iOS/NavigationController.swift
+++ b/Sources/iOS/NavigationController.swift
@@ -69,6 +69,11 @@ open class NavigationController: UINavigationController {
     super.init(navigationBarClass: NavigationBar.self, toolbarClass: nil)
     setViewControllers([rootViewController], animated: false)
   }
+    
+    public init(rootViewController: UIViewController, navigationBarClass: Swift.AnyClass?) {
+        super.init(navigationBarClass: navigationBarClass, toolbarClass: nil)
+        setViewControllers([rootViewController], animated: false)
+    }
   
   open override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)


### PR DESCRIPTION
#1074 

Adds an initializer to NavigationController that takes a custom navigation bar class parameter; this parameter is simply passed to super.

This extends NavigationController with the ability to be initialized with a user-defined subclass of NavigationBar.