### PR TITLE
Added ErrorTextField validation

### DIFF
--- a/Material.xcodeproj/project.pbxproj
+++ b/Material.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		9DF352421FED20C900B2A11B /* BaseIconLayerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF352411FED20C900B2A11B /* BaseIconLayerButton.swift */; };
 		9DF352441FED20ED00B2A11B /* RadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF352431FED20ED00B2A11B /* RadioButton.swift */; };
 		9DF352461FED210000B2A11B /* CheckButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF352451FED210000B2A11B /* CheckButton.swift */; };
+		9DF58CEE20C098C60098968D /* ErrorTextFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF58CED20C098C60098968D /* ErrorTextFieldValidator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -297,6 +298,7 @@
 		9DF352411FED20C900B2A11B /* BaseIconLayerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseIconLayerButton.swift; sourceTree = "<group>"; };
 		9DF352431FED20ED00B2A11B /* RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButton.swift; sourceTree = "<group>"; };
 		9DF352451FED210000B2A11B /* CheckButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckButton.swift; sourceTree = "<group>"; };
+		9DF58CED20C098C60098968D /* ErrorTextFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTextFieldValidator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -315,6 +317,7 @@
 				96BCB79E1CB40DC500C806FE /* TextView.swift */,
 				96BCB79C1CB40DC500C806FE /* TextField.swift */,
 				961F18E71CD93E3E008927C5 /* ErrorTextField.swift */,
+				9DF58CED20C098C60098968D /* ErrorTextFieldValidator.swift */,
 			);
 			name = Text;
 			sourceTree = "<group>";
@@ -1005,6 +1008,7 @@
 				965E80CE1DD4C50600D61E4B /* FABButton.swift in Sources */,
 				965E80CF1DD4C50600D61E4B /* FlatButton.swift in Sources */,
 				965E80D01DD4C50600D61E4B /* RaisedButton.swift in Sources */,
+				9DF58CEE20C098C60098968D /* ErrorTextFieldValidator.swift in Sources */,
 				96A183631E0C6CE200083C30 /* FABMenu.swift in Sources */,
 				965E80D11DD4C50600D61E4B /* IconButton.swift in Sources */,
 				965E80D21DD4C50600D61E4B /* Color.swift in Sources */,

--- a/Sources/iOS/ErrorTextField.swift
+++ b/Sources/iOS/ErrorTextField.swift
@@ -64,6 +64,7 @@ open class ErrorTextField: TextField {
     }
   }
   
+  /// Hide or show error text.
   open var isErrorRevealed: Bool {
     get {
       return !errorLabel.isHidden

--- a/Sources/iOS/ErrorTextField.swift
+++ b/Sources/iOS/ErrorTextField.swift
@@ -31,18 +31,65 @@
 import UIKit
 
 open class ErrorTextField: TextField {
-  /// Controls the visibility of detailLabel
+  
+  /// The errorLabel UILabel that is displayed.
   @IBInspectable
-  open var isErrorRevealed = false {
-    didSet {
-      detailLabel.isHidden = !isErrorRevealed
+  open let errorLabel = UILabel()
+  
+  /// The errorLabel text value.
+  @IBInspectable
+  open var error: String? {
+    get {
+      return errorLabel.text
+    }
+    set(value) {
+      errorLabel.text = value
       layoutSubviews()
+    }
+  }
+  
+  /// Error text color
+  @IBInspectable
+  open var errorColor = Color.red.base {
+    didSet {
+      errorLabel.textColor = errorColor
+    }
+  }
+  
+  /// Vertical distance for the errorLabel from the divider.
+  @IBInspectable
+  open var errorVerticalOffset: CGFloat = 8 {
+    didSet {
+      layoutSubviews()
+    }
+  }
+  
+  open var isErrorRevealed: Bool {
+    get {
+      return !errorLabel.isHidden
+    }
+    set {
+      errorLabel.isHidden = !newValue
+      detailLabel.isHidden = newValue
     }
   }
   
   open override func prepare() {
     super.prepare()
     isErrorRevealed = false
-    detailColor = Color.red.base
+    prepareErrorLabel()
+  }
+  
+  /// Prepares the errorLabel.
+  func prepareErrorLabel() {
+    errorLabel.font = RobotoFont.regular(with: 12)
+    errorLabel.numberOfLines = 0
+    errorColor = { errorColor }() // call didSet
+    addSubview(errorLabel)
+  }
+  
+  open override func layoutSubviews() {
+    super.layoutSubviews()
+    layoutBottomLabel(label: errorLabel, verticalOffset: errorVerticalOffset)
   }
 }

--- a/Sources/iOS/ErrorTextFieldValidator.swift
+++ b/Sources/iOS/ErrorTextFieldValidator.swift
@@ -1,0 +1,131 @@
+//
+//  ErrorTextFieldValidator.swift
+//  Material
+//
+//  Created by Orkhan Alikhanov on 30/05/2018.
+//  Copyright © 2018 CosmicMind, Inc. All rights reserved.
+//
+
+import UIKit
+import Motion
+
+open class ErrorTextFieldValidator: NSObject {
+  public typealias ValidationClosure = (String) -> Bool
+  open var closures: [(code: ValidationClosure, msg: String)] = []
+  open weak var textField: ErrorTextField?
+  
+  open var autoValidationType: AutoValidationType = .default
+  open var autoValidateOnlyIfErrorIsShownOnce = true
+  open var isErrorShownOnce = false
+  
+  public init(textField: ErrorTextField) {
+    self.textField = textField
+    super.init()
+    
+    textField.addTarget(self, action: #selector(checkIfErrorHasGone), for: .editingChanged)
+  }
+  
+  @objc
+  private func checkIfErrorHasGone() {
+    guard let textField = textField else { return }
+    if autoValidateOnlyIfErrorIsShownOnce && !isErrorShownOnce { return }
+    
+    switch autoValidationType {
+    case .none: break
+    case .custom(let closure):
+      closure(textField)
+    case .default:
+        _  = textField.isValid() // will hide if needed
+    }
+  }
+  
+  open func isValid(deferred: Bool) -> Bool {
+    guard let textField = textField else { return false }
+    if !deferred { textField.isErrorRevealed = false }
+    for block in closures {
+      if !block.code(textField.text ?? "") {
+        if !deferred {
+          textField.error = block.msg
+          textField.isErrorRevealed = true
+          isErrorShownOnce = true
+        }
+        return false
+      }
+    }
+    return true
+  }
+  
+  @discardableResult
+  open func validate(msg: String, when code: @escaping ValidationClosure) -> Self {
+    closures.append((code, msg))
+    return self
+  }
+  
+  public enum AutoValidationType {
+    case none
+    case `default`
+    case custom((ErrorTextField) -> Void)
+  }
+}
+
+private var AssociatedInstanceKey: UInt8 = 0
+extension ErrorTextField {
+  open var validator: ErrorTextFieldValidator {
+    get {
+      return AssociatedObject.get(base: self, key: &AssociatedInstanceKey) {
+        return ErrorTextFieldValidator(textField: self)
+      }
+    }
+    set(value) {
+      AssociatedObject.set(base: self, key: &AssociatedInstanceKey, value: value)
+    }
+  }
+  
+  open func isValid(deferred: Bool = false) -> Bool {
+    return validator.isValid(deferred: deferred)
+  }
+}
+
+public extension ErrorTextFieldValidator {
+  @discardableResult
+  func email(msg: String) -> Self {
+    return regex(msg: msg, pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}")
+  }
+  
+  @discardableResult
+  func username(msg: String) -> Self {
+    return regex(msg: msg, pattern: "^[a-zA-Z0-9]+([_\\s\\-\\.\\']?[a-zA-Z0-9])*$")
+  }
+  
+  @discardableResult
+  func regex(msg: String, pattern: String) -> Self {
+    return validate(msg: msg) {
+      let pred = NSPredicate(format: "SELF MATCHES %@", pattern)
+      return pred.evaluate(with: $0)
+    }
+  }
+  
+  @discardableResult
+  func min(length: Int, msg: String, trimmingSet: CharacterSet? = .whitespacesAndNewlines) -> Self {
+    let trimmingSet = trimmingSet ?? .init()
+    return validate(msg: msg) {
+      $0.trimmingCharacters(in: trimmingSet).count >= length
+    }
+  }
+  
+  @discardableResult
+  func notEmpty(msg: String, trimmingSet: CharacterSet? = .whitespacesAndNewlines) -> Self {
+    let trimmingSet = trimmingSet ?? .init()
+    return validate(msg: msg) {
+      $0.trimmingCharacters(in: trimmingSet).isEmpty == false
+    }
+  }
+  
+  @discardableResult
+  func noWhitespaces(msg: String) -> Self {
+    return validate(msg: msg) {
+      $0.rangeOfCharacter(from: .whitespaces) == nil
+    }
+  }
+}
+

--- a/Sources/iOS/ErrorTextFieldValidator.swift
+++ b/Sources/iOS/ErrorTextFieldValidator.swift
@@ -15,7 +15,6 @@ open class ErrorTextFieldValidator {
   open weak var textField: ErrorTextField?
   
   open var autoValidationType: AutoValidationType = .default
-  open var autoValidateOnlyIfErrorIsShownOnce = true
   open var isErrorShownOnce = false
   
   public init(textField: ErrorTextField) {
@@ -30,14 +29,16 @@ open class ErrorTextFieldValidator {
   @objc
   private func checkIfErrorHasGone() {
     guard let textField = textField else { return }
-    if autoValidateOnlyIfErrorIsShownOnce && !isErrorShownOnce { return }
     
     switch autoValidationType {
     case .none: break
     case .custom(let closure):
       closure(textField)
     case .default:
-        textField.isValid()
+      guard isErrorShownOnce else { return }
+      textField.isValid()
+    case .always:
+      textField.isValid()
     }
   }
   
@@ -67,6 +68,7 @@ open class ErrorTextFieldValidator {
   public enum AutoValidationType {
     case none
     case `default`
+    case always
     case custom((ErrorTextField) -> Void)
   }
 }

--- a/Sources/iOS/ErrorTextFieldValidator.swift
+++ b/Sources/iOS/ErrorTextFieldValidator.swift
@@ -1,33 +1,97 @@
-//
-//  ErrorTextFieldValidator.swift
-//  Material
-//
-//  Created by Orkhan Alikhanov on 30/05/2018.
-//  Copyright © 2018 CosmicMind, Inc. All rights reserved.
-//
+/*
+ * Copyright (C) 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Original Inspiration & Author
+ * Copyright (C) 2018 Orkhan Alikhanov <orkhan.alikhanov@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  *  Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  *  Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 import UIKit
 import Motion
 
+/**
+ Validator plugin for ErrorTextField and subclasses.
+ Can be accessed via `textField.validator`
+ ### Example
+ ```swift
+ field.validator
+      .notEmpty(message: "Choose username")
+      .min(length: 3, message: "Minimum 3 characters")
+      .noWhitespaces(message: "Username cannot contain spaces")
+      .username(message: "Unallowed characters in username")
+ }
+ ```
+ */
 open class ErrorTextFieldValidator {
+  /// A typealias for validation closure.
   public typealias ValidationClosure = (_ text: String) -> Bool
+  
+  /// Validation closures and their error messages.
   open var closures: [(code: ValidationClosure, message: String)] = []
+  
+  /// A reference to the textField.
   open weak var textField: ErrorTextField?
   
+  /// Behavior for auto-validation.
   open var autoValidationType: AutoValidationType = .default
+  
+  /**
+   A flag indicating if error message is shown at least once.
+   Used for `AutoValidationType.default`.
+   */
   open var isErrorShownOnce = false
   
+  /**
+   Initializes validator.
+   - Parameter textField: An ErrorTextField to validate.
+   */
   public init(textField: ErrorTextField) {
     self.textField = textField
     prepare()
   }
   
+  /**
+   Prepares the validator instance when intialized. When subclassing,
+   it is recommended to override the prepare method
+   to initialize property values and other setup operations.
+   The super.prepare method should always be called immediately
+   when subclassing.
+   */
   open func prepare() {
-    textField?.addTarget(self, action: #selector(checkIfErrorHasGone), for: .editingChanged)
+    textField?.addTarget(self, action: #selector(autoValidate), for: .editingChanged)
   }
   
+  /**
+   Validates textField based on `autoValidationType`.
+   This method is called when textField.text changes.
+   */
   @objc
-  private func checkIfErrorHasGone() {
+  private func autoValidate() {
     guard let textField = textField else { return }
     
     switch autoValidationType {
@@ -42,6 +106,12 @@ open class ErrorTextFieldValidator {
     }
   }
   
+  /**
+   Validates textField.text against criteria defined in `closures`
+   and shows relevant error message on failure.
+   - Parameter isDeferred: Defer showing error message.
+   - Returns: Boolean indicating if validation passed.
+   */
   @discardableResult
   open func isValid(isDeferred: Bool) -> Bool {
     guard let textField = textField else { return false }
@@ -59,22 +129,46 @@ open class ErrorTextFieldValidator {
     return true
   }
   
+  
+  /** Adds provided closure and its error message to the validation chain.
+   - Parameter message: A message to be shown when validation fails.
+   - Parameter code: Closure to run for validation.
+   - Returns: Validator itself to allow chaining.
+   */
   @discardableResult
   open func validate(message: String, when code: @escaping ValidationClosure) -> Self {
     closures.append((code, message))
     return self
   }
   
+  
+  /**
+   Types for determining behaviour of auto-validation
+   which is run when textField.text changes.
+   */
   public enum AutoValidationType {
+    /// Turn off.
     case none
+    
+    /// Run validation only if error is shown once.
     case `default`
+    
+    /// Always run validation.
     case always
+    
+    /**
+     Custom auto-validation logic passed as closure
+     which accepts ErrorTextField. Closure is called
+     when `textField.text` changes.
+     */
     case custom((ErrorTextField) -> Void)
   }
 }
 
+/// Memory key pointer for `validator`.
 private var AssociatedInstanceKey: UInt8 = 0
 extension ErrorTextField {
+  /// A reference to validator.
   open var validator: ErrorTextFieldValidator {
     get {
       return AssociatedObject.get(base: self, key: &AssociatedInstanceKey) {
@@ -86,6 +180,12 @@ extension ErrorTextField {
     }
   }
   
+  /**
+   Validates textField.text against criteria defined in `closures`
+   and shows relevant error message on failure.
+   - Parameter isDeferred: Defer showing error message. Default is false.
+   - Returns: Boolean indicating if validation passed.
+   */
   @discardableResult
   open func isValid(isDeferred: Bool = false) -> Bool {
     return validator.isValid(isDeferred: isDeferred)
@@ -93,16 +193,32 @@ extension ErrorTextField {
 }
 
 public extension ErrorTextFieldValidator {
+  /**
+   Validate that field contains correct email address.
+   - Parameter message: A message to show for incorrect emails.
+   - Returns: Validator itself to allow chaining.
+   */
   @discardableResult
   func email(message: String) -> Self {
     return regex(message: message, pattern: "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}")
   }
   
+  /**
+   Validate that field contains allowed usernames characters.
+   - Parameter message: A message to show for disallowed usernames.
+   - Returns: Validator itself to allow chaining.
+   */
   @discardableResult
   func username(message: String) -> Self {
     return regex(message: message, pattern: "^[a-zA-Z0-9]+([_\\s\\-\\.\\']?[a-zA-Z0-9])*$")
   }
   
+  /**
+   Validate that field text matches provided regex pattern.
+   - Parameter message: A message to show for unmatched texts.
+   - Parameter pattern: A regex pattern to match.
+   - Returns: Validator itself to allow chaining.
+   */
   @discardableResult
   func regex(message: String, pattern: String) -> Self {
     return validate(message: message) {
@@ -111,6 +227,13 @@ public extension ErrorTextFieldValidator {
     }
   }
   
+  /**
+   Validate that field text has minimum `length`.
+   - Parameter length: Minimum allowed text length.
+   - Parameter message: A message to show when requirement is not met.
+   - Parameter trimmingSet: A trimming CharacterSet for trimming text before validation.
+   - Returns: Validator itself to allow chaining.
+   */
   @discardableResult
   func min(length: Int, message: String, trimmingSet: CharacterSet? = .whitespacesAndNewlines) -> Self {
     let trimmingSet = trimmingSet ?? .init()
@@ -119,6 +242,27 @@ public extension ErrorTextFieldValidator {
     }
   }
   
+  /**
+   Validate that field text has maximum `length`.
+   - Parameter length: Minimum allowed text length.
+   - Parameter message: A message to show when requirement is not met.
+   - Parameter trimmingSet: A trimming CharacterSet for trimming text before validation.
+   - Returns: Validator itself to allow chaining.
+   */
+  @discardableResult
+  func max(length: Int, message: String, trimmingSet: CharacterSet? = .whitespacesAndNewlines) -> Self {
+    let trimmingSet = trimmingSet ?? .init()
+    return validate(message: message) {
+      $0.trimmingCharacters(in: trimmingSet).count <= length
+    }
+  }
+  
+  /**
+   Validate that field text is not empty.
+   - Parameter message: A message to show when requirement is not met.
+   - Parameter trimmingSet: A trimming CharacterSet for trimming text before validation.
+   - Returns: Validator itself to allow chaining.
+   */
   @discardableResult
   func notEmpty(message: String, trimmingSet: CharacterSet? = .whitespacesAndNewlines) -> Self {
     let trimmingSet = trimmingSet ?? .init()
@@ -127,6 +271,13 @@ public extension ErrorTextFieldValidator {
     }
   }
   
+  
+  /**
+   Validate that field text contains no whitespaces.
+   - Parameter message: A message to show when requirement is not met.
+   - Parameter trimmingSet: A trimming CharacterSet for trimming text before validation.
+   - Returns: Validator itself to allow chaining.
+   */
   @discardableResult
   func noWhitespaces(message: String) -> Self {
     return validate(message: message) {
@@ -134,4 +285,3 @@ public extension ErrorTextFieldValidator {
     }
   }
 }
-

--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -268,7 +268,7 @@ open class TextField: UITextField {
   @IBInspectable
   open var detailVerticalOffset: CGFloat = 8 {
     didSet {
-      layoutDetailLabel()
+      layoutSubviews()
     }
   }
   
@@ -412,7 +412,7 @@ open class TextField: UITextField {
     super.layoutSubviews()
     layoutShape()
     layoutPlaceholderLabel()
-    layoutDetailLabel()
+    layoutBottomLabel(label: detailLabel, verticalOffset: detailVerticalOffset)
     layoutButton(button: clearIconButton)
     layoutButton(button: visibilityIconButton)
     layoutDivider()
@@ -573,16 +573,7 @@ fileprivate extension TextField {
     
     placeholderLabel.frame.origin.y = -placeholderLabel.bounds.height + placeholderVerticalOffset
   }
-  
-  /// Layout the detailLabel.
-  func layoutDetailLabel() {
-    let c = dividerContentEdgeInsets
-    detailLabel.frame.size.height = detailLabel.sizeThatFits(CGSize(width: bounds.width, height: .greatestFiniteMagnitude)).height
-    detailLabel.frame.origin.x = c.left
-    detailLabel.frame.origin.y = bounds.height + detailVerticalOffset
-    detailLabel.frame.size.width = bounds.width - c.left - c.right
-  }
-  
+
   /// Layout the a button.
   func layoutButton(button: UIButton?) {
     button?.frame = CGRect(x: bounds.width - bounds.height, y: 0, width: bounds.height, height: bounds.height)
@@ -597,6 +588,17 @@ fileprivate extension TextField {
     let w = leftViewWidth
     v.frame = CGRect(x: 0, y: 0, width: w, height: bounds.height)
     dividerContentEdgeInsets.left = w
+  }
+}
+
+internal extension TextField {
+  /// Layout given label at the bottom with the vertical offset provided.
+  func layoutBottomLabel(label: UILabel, verticalOffset: CGFloat) {
+    let c = dividerContentEdgeInsets
+    label.frame.origin.x = c.left
+    label.frame.origin.y = bounds.height + verticalOffset
+    label.frame.size.width = bounds.width - c.left - c.right
+    label.frame.size.height = label.sizeThatFits(CGSize(width: label.bounds.width, height: .greatestFiniteMagnitude)).height
   }
 }
 


### PR DESCRIPTION
First change is that, new `errorLabel` field is added to `ErrorTextField`. It will be shown in place of `detailLabel` when `isErrorRevealed` is set to `true`. Obviously, it's added to let both`errorLabel` and `detailLabel` have their own style and text.

Secondly, `ErrorTextFieldValidator` is added which allows to set various validation criteria and to check if `textField.text` passes them or not. On failure `errorLabel` will be shown with corresponding error message set alongside the validation criterion. Basic setup is like so:

```swift
let usernameField = ErrorTextField()
usernameField.placeholder = "Username"
usernameField.detail = "You can use letters, numbers & periods"
usernameField.validator
  .notEmpty(msg: "Choose username")
  .min(length: 3, msg: "Min 3 characters")
  .noWhitespaces(msg: "Username cannot contain spaces")
  .username(msg: "Unallowed characters in username")

```

Validation will be checked on the sequence that's provided, so order is important.

Calling `usernameField.isValid()` will return boolean value indicating if validation passed. On failure corresponding error message will be shown. If developer needs to know validation status without showing show error message on fail, he can pass `true` to `deferred` parameter. `usernameField.isValid(deferred: true)`. Note that when a validation fails others (in the sequence) will not be checked.

Custom validation closure can also be set to if provided ones does not cover developer's criteria
```swift
usernameField.validator.validate(msg: "Letter 'A' is not allowed") { text in
  return text.contains("A") == false // must not contain 'A'
}
```

By default auto validation is delayed until first error message appears. After first validation failure, validation will be rechecked on every change in textField: 
![](https://user-images.githubusercontent.com/15037839/40856638-a38d455a-65e9-11e8-9b83-58aa2da58acd.gif)
<sup>Auto-validation is turned off until validation fails first time, which happens when `isValid()` is called on Sign Up button is tapped</sup>
However, we have option turn auto validation on without waiting first error to occur.
```swift
usernameField.autoValidateOnlyIfErrorIsShownOnce = false //now the field will be auto-validated as user types
```

![](https://user-images.githubusercontent.com/15037839/40856794-208f7604-65ea-11e8-9783-9f904e793aee.gif)

<sup>Auto-validation runs as user types</sup>

Turning auto validation off:
```swift
usernameField.autoValidationType = .none // turned off
usernameField.autoValidationType = .default // turned on
```

Setting custom auto validation which will be called on every textField change:

```swift
usernameField.autoValidationType = .custom { textField in
  _ = textField.isValid() // this is default behavior, simply reruns validation 
}
```
