### PR TITLE
Should always trigger TabBar Delegate

### DIFF
--- a/Material.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Material.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -245,9 +245,10 @@ fileprivate extension TabsController {
       
       completion?(isFinishing)
       
-      if isTriggeredByUserInteraction {
-        s.delegate?.tabsController?(tabsController: s, didSelect: viewController)
-      }
+//       if isTriggeredByUserInteraction {
+      s.delegate?.tabsController?(tabsController: s, didSelect: viewController)
+//       }
+                                          
     }
   }
 }

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -245,10 +245,10 @@ fileprivate extension TabsController {
       
       completion?(isFinishing)
       
-//       if isTriggeredByUserInteraction {
-      s.delegate?.tabsController?(tabsController: s, didSelect: viewController)
-//       }
-                                          
+      if isTriggeredByUserInteraction {
+        s.delegate?.tabsController?(tabsController: s, didSelect: viewController)
+      }
+      
     }
   }
 }
@@ -412,7 +412,7 @@ extension TabsController {
         guard isFinishing else {
           return
         }
-        
+        self?.delegate?.tabsController(tabsController: self, didSelect: s.viewControllers[index])
         self?.selectedIndex = index
       }
     }

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -412,7 +412,7 @@ extension TabsController {
         guard isFinishing else {
           return
         }
-        self?.delegate?.tabsController(tabsController: self, didSelect: s.viewControllers[index])
+        self?.delegate?.tabsController?(tabsController: s, didSelect: s.viewControllers[index])
         self?.selectedIndex = index
       }
     }


### PR DESCRIPTION
Problem: when swipe TabsControllerDelegate not trigger.
TabsControllerDelegate Only trigger when taps on TabBarItems

Solution remove the check isTriggeredByUserInteraction
to call the delegate

tabsController?(tabsController: s, didSelect: viewController)
