### PR TITLE
Removed unnecessary convenience initializers.

### DIFF
--- a/Sources/iOS/Bar.swift
+++ b/Sources/iOS/Bar.swift
@@ -157,11 +157,6 @@ open class Bar: View {
     super.init(frame: frame)
   }
   
-  /// Convenience initializer.
-  public convenience init() {
-    self.init(frame: .zero)
-  }
-  
   /**
    A convenience initializer with parameter settings.
    - Parameter leftViews: An Array of UIViews that go on the left side.

--- a/Sources/iOS/Button.swift
+++ b/Sources/iOS/Button.swift
@@ -188,11 +188,6 @@ open class Button: UIButton, Pulseable, PulseableLayer {
     prepare()
   }
   
-  /// A convenience initializer.
-  public convenience init() {
-    self.init(frame: .zero)
-  }
-  
   /**
    A convenience initializer that acceps an image and tint
    - Parameter image: A UIImage.

--- a/Sources/iOS/Card.swift
+++ b/Sources/iOS/Card.swift
@@ -168,11 +168,6 @@ open class Card: PulseView {
     super.init(frame: frame)
   }
   
-  /// A convenience initializer.
-  public convenience init() {
-    self.init(frame: .zero)
-  }
-  
   /**
    A convenience initiazlier.
    - Parameter toolbar: An optional Toolbar.

--- a/Sources/iOS/CollectionReusableView.swift
+++ b/Sources/iOS/CollectionReusableView.swift
@@ -228,11 +228,6 @@ open class CollectionReusableView: UICollectionReusableView, Pulseable, Pulseabl
     prepare()
   }
   
-  /// A convenience initializer.
-  public convenience init() {
-    self.init(frame: .zero)
-  }
-  
   open override func layoutSubviews() {
     super.layoutSubviews()
     layoutShape()

--- a/Sources/iOS/CollectionViewCell.swift
+++ b/Sources/iOS/CollectionViewCell.swift
@@ -186,11 +186,6 @@ open class CollectionViewCell: UICollectionViewCell, Pulseable, PulseableLayer {
     prepare()
   }
   
-  /// A convenience initializer.
-  public convenience init() {
-    self.init(frame: .zero)
-  }
-  
   open override func layoutSubviews() {
     super.layoutSubviews()
     layoutShape()

--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -120,11 +120,6 @@ open class NavigationBar: UINavigationBar {
     prepare()
   }
   
-  /// A convenience initializer.
-  public convenience init() {
-    self.init(frame: .zero)
-  }
-  
   open override func sizeThatFits(_ size: CGSize) -> CGSize {
     return intrinsicContentSize
   }

--- a/Sources/iOS/TableView.swift
+++ b/Sources/iOS/TableView.swift
@@ -53,11 +53,6 @@ open class TableView: UITableView {
     self.init(frame: frame, style: .plain)
   }
   
-  /// A convenience initializer that initializes the object.
-  public convenience init() {
-    self.init(frame: .zero)
-  }
-  
   /**
    Prepares the view instance when intialized. When subclassing,
    it is recommended to override the prepare method

--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -403,11 +403,6 @@ open class TextField: UITextField {
     prepare()
   }
   
-  /// A convenience initializer.
-  public convenience init() {
-    self.init(frame: .zero)
-  }
-  
   open override func layoutSubviews() {
     super.layoutSubviews()
     layoutShape()

--- a/Sources/iOS/View.swift
+++ b/Sources/iOS/View.swift
@@ -156,11 +156,6 @@ open class View: UIView {
     prepare()
   }
   
-  /// Convenience initializer.
-  public convenience init() {
-    self.init(frame: .zero)
-  }
-  
   open override func layoutSubviews() {
     super.layoutSubviews()
     layoutShape()


### PR DESCRIPTION
#1085
Removed all redundant convenience initializer:
```swift
public convenience init() {
  self.init(frame: .zero)
}
```

Only kept in `TextView` because it has some logic there:

https://github.com/CosmicMind/Material/blob/06d223da770f50c33808cd7dc601e70e544f995f/Sources/iOS/TextView.swift#L233-L247