### PR TITLE
Added update() to Grid

### DIFF
--- a/Sources/iOS/Grid.swift
+++ b/Sources/iOS/Grid.swift
@@ -189,6 +189,16 @@ public struct Grid {
     reload()
   }
   
+  /**
+   Update grid in a deferred block.
+   - Parameter block: An update code block.
+   */
+  public mutating func update(_ block: (Grid) -> Void) {
+    begin()
+    block(self)
+    commit()
+  }
+  
   /// Reload the button layout.
   public func reload() {
     guard !isDeferred else {


### PR DESCRIPTION
Now, instead of:
```swift
scrollView.grid.begin()
scrollView.grid.views = tabItems
scrollView.grid.axis.columns = tabItems.count
scrollView.grid.contentEdgeInsets = tabItemsContentEdgeInsets
scrollView.grid.interimSpace = tabItemsInterimSpace
scrollView.grid.commit()
```
We can use:
```swift
scrollView.grid.update {
  $0.views = tabItems
  $0.axis.columns = tabItems.count
  $0.contentEdgeInsets = tabItemsContentEdgeInsets
  $0.interimSpace = tabItemsInterimSpace
}
```