### PR TITLE
Introducing Theming to Material

### DIFF
--- a/Material.xcodeproj/project.pbxproj
+++ b/Material.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		96E3C39A1D3A1CC20086A024 /* ErrorTextField.swift in Headers */ = {isa = PBXBuildFile; fileRef = 961F18E71CD93E3E008927C5 /* ErrorTextField.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		96E3C39C1D3A1CC20086A024 /* Offset.swift in Headers */ = {isa = PBXBuildFile; fileRef = 968C99461D377849000074FF /* Offset.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		96F1A5531F24F17A001D8CAF /* TabsController.swift in Headers */ = {isa = PBXBuildFile; fileRef = 96E09DC71F2287E50000B121 /* TabsController.swift */; settings = {ATTRIBUTES = (Public, ); }; };
+		9D00EBB4216675FB00DBCD69 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D00EBB3216675FB00DBCD69 /* Theme.swift */; };
 		9D054A6520D175AC00D0528D /* Material+UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D054A6320D175AC00D0528D /* Material+UIButton.swift */; };
 		9D054A6620D175AC00D0528D /* Material+UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D054A6420D175AC00D0528D /* Material+UILabel.swift */; };
 		9D39A81B20FE8ED100BA8FA1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D39A81A20FE8ED100BA8FA1 /* ViewController.swift */; };
@@ -292,6 +293,7 @@
 		96E09DC71F2287E50000B121 /* TabsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabsController.swift; sourceTree = "<group>"; };
 		96E3C3931D397AE90086A024 /* Material+UIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Material+UIView.swift"; sourceTree = "<group>"; };
 		96F1DC871D654FDF0025F925 /* Material+CALayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Material+CALayer.swift"; sourceTree = "<group>"; };
+		9D00EBB3216675FB00DBCD69 /* Theme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		9D054A6320D175AC00D0528D /* Material+UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Material+UIButton.swift"; sourceTree = "<group>"; };
 		9D054A6420D175AC00D0528D /* Material+UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Material+UILabel.swift"; sourceTree = "<group>"; };
 		9D39A81A20FE8ED100BA8FA1 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 				963FBF011D6696AB008F8512 /* Tab */,
 				966ECF2B1CF4C21B00BB0BDF /* Table */,
 				96090B031D9D709E00709CA6 /* Text */,
+				9D00EBB2216675A800DBCD69 /* Theme */,
 				963FBF001D66964F008F8512 /* Toolbar */,
 				9626CA951DAB5370003E2611 /* Transition */,
 				96BCB8061CB40FD000C806FE /* Type */,
@@ -758,6 +761,14 @@
 				965532281E47E388005C2792 /* SpringAnimation.swift */,
 			);
 			name = Animation;
+			sourceTree = "<group>";
+		};
+		9D00EBB2216675A800DBCD69 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				9D00EBB3216675FB00DBCD69 /* Theme.swift */,
+			);
+			name = Theme;
 			sourceTree = "<group>";
 		};
 		9DE84D6E1FF0250E00586C8B /* ButtonGroup */ = {
@@ -1002,6 +1013,7 @@
 				966C17731F0439F600D3E83C /* Material+MotionAnimation.swift in Sources */,
 				965E80E51DD4C53300D61E4B /* PulseAnimation.swift in Sources */,
 				9DE84D721FF0252600586C8B /* RadioButtonGroup.swift in Sources */,
+				9D00EBB4216675FB00DBCD69 /* Theme.swift in Sources */,
 				965E80FE1DD4D59500D61E4B /* ToolbarController.swift in Sources */,
 				96328B971E05C0BB009A4C90 /* TableView.swift in Sources */,
 				965E80F81DD4D59500D61E4B /* ImageCard.swift in Sources */,

--- a/Sources/iOS/BaseIconLayerButton.swift
+++ b/Sources/iOS/BaseIconLayerButton.swift
@@ -142,6 +142,14 @@ open class BaseIconLayerButton: Button {
             reloadImage()
         }
     }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    setIconColor(theme.secondary, for: .selected)
+    setIconColor(theme.onSurface.withAlphaComponent(0.38), for: .normal)
+    titleColor = theme.onSurface.withAlphaComponent(0.60)
+  }
     
     
     /// This might be considered as a hackish way, but it's just manipulation

--- a/Sources/iOS/BaseIconLayerButton.swift
+++ b/Sources/iOS/BaseIconLayerButton.swift
@@ -20,6 +20,7 @@ open class BaseIconLayerButton: Button {
     open override var isSelected: Bool {
         didSet {
             iconLayer.setSelected(isSelected, animated: false)
+            updatePulseColor()
         }
     }
     
@@ -150,6 +151,10 @@ open class BaseIconLayerButton: Button {
     setIconColor(theme.secondary, for: .selected)
     setIconColor(theme.onSurface.withAlphaComponent(0.38), for: .normal)
     titleColor = theme.onSurface.withAlphaComponent(0.60)
+    
+    selectedPulseColor = theme.secondary
+    normalPulseColor = theme.onSurface
+    updatePulseColor()
   }
     
     
@@ -168,6 +173,18 @@ open class BaseIconLayerButton: Button {
         UIGraphicsEndImageContext()
         self.image = image
     }
+  
+  /// Pulse color for selected state.
+  open var selectedPulseColor = Color.white
+  
+  /// Pulse color for normal state.
+  open var normalPulseColor = Color.white
+}
+
+private extension BaseIconLayerButton {
+  func updatePulseColor() {
+    pulseColor = isSelected ? selectedPulseColor : normalPulseColor
+  }
 }
 
 // MARK: - BaseIconLayer

--- a/Sources/iOS/BaseIconLayerButton.swift
+++ b/Sources/iOS/BaseIconLayerButton.swift
@@ -84,6 +84,7 @@ open class BaseIconLayerButton: Button {
     open override func prepare() {
         super.prepare()
         layer.addSublayer(iconLayer)
+        iconLayer.prepare()
         contentHorizontalAlignment = .left // default was .center
         reloadImage()
     }
@@ -191,16 +192,6 @@ internal class BaseIconLayer: CALayer {
             normalColor = { normalColor }()
             disabledColor = { disabledColor }()
         }
-    }
-    
-    override init() {
-        super.init()
-        prepare()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        prepare()
     }
     
     func prepare() {

--- a/Sources/iOS/BaseIconLayerButton.swift
+++ b/Sources/iOS/BaseIconLayerButton.swift
@@ -123,7 +123,7 @@ open class BaseIconLayerButton: Button {
     ///
     /// This property affects `intrinsicContentSize` and `sizeThatFits(_:)`
     /// Use `iconEdgeInsets` to set margins.
-    open var iconSize: CGFloat = 16 {
+    open var iconSize: CGFloat = 18 {
         didSet {
             reloadImage()
         }
@@ -137,8 +137,8 @@ open class BaseIconLayerButton: Button {
     ///
     /// You can use `iconSize` and this property, or `titleEdgeInsets` and `contentEdgeInsets` to position
     /// the icon however you want.
-    /// For negative values, behavior is undefined. Default is `5.0` for all four margins
-    open var iconEdgeInsets = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5) {
+    /// For negative values, behavior is undefined. Default is `8.0` for all four margins
+    open var iconEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8) {
         didSet {
             reloadImage()
         }

--- a/Sources/iOS/BottomNavigationController.swift
+++ b/Sources/iOS/BottomNavigationController.swift
@@ -51,7 +51,7 @@ private class MaterialTabBar: UITabBar {
   }
 }
 
-open class BottomNavigationController: UITabBarController {
+open class BottomNavigationController: UITabBarController, Themeable {
   /// A Boolean that controls if the swipe feature is enabled.
   open var isSwipeEnabled = true {
     didSet {
@@ -168,6 +168,17 @@ open class BottomNavigationController: UITabBarController {
     prepareTabBar()
     isSwipeEnabled = true
     isMotionEnabled = true
+    applyCurrentTheme()
+  }
+  
+  open func apply(theme: Theme) {
+    tabBar.tintColor = theme.secondary
+    tabBar.barTintColor = theme.background
+    tabBar.dividerColor = theme.onSurface.withAlphaComponent(0.12)
+    
+    if #available(iOS 10.0, *) {
+      tabBar.unselectedItemTintColor = theme.onSurface.withAlphaComponent(0.54)
+    }
   }
 }
 

--- a/Sources/iOS/BottomNavigationController.swift
+++ b/Sources/iOS/BottomNavigationController.swift
@@ -171,6 +171,10 @@ open class BottomNavigationController: UITabBarController, Themeable {
     applyCurrentTheme()
   }
   
+  /**
+   Applies the given theme.
+   - Parameter theme: A Theme.
+   */
   open func apply(theme: Theme) {
     tabBar.tintColor = theme.secondary
     tabBar.barTintColor = theme.background

--- a/Sources/iOS/Button.swift
+++ b/Sources/iOS/Button.swift
@@ -195,8 +195,8 @@ open class Button: UIButton, Pulseable, PulseableLayer, Themeable {
    */
   public init(image: UIImage?, tintColor: UIColor = Color.blue.base) {
     super.init(frame: .zero)
-    prepare(with: image, tintColor: tintColor)
     prepare()
+    prepare(with: image, tintColor: tintColor)
   }
   
   /**
@@ -206,8 +206,8 @@ open class Button: UIButton, Pulseable, PulseableLayer, Themeable {
    */
   public init(title: String?, titleColor: UIColor = Color.blue.base) {
     super.init(frame: .zero)
-    prepare(with: title, titleColor: titleColor)
     prepare()
+    prepare(with: title, titleColor: titleColor)
   }
   
   open override func layoutSubviews() {

--- a/Sources/iOS/Button.swift
+++ b/Sources/iOS/Button.swift
@@ -31,7 +31,7 @@
 import UIKit
 import Motion
 
-open class Button: UIButton, Pulseable, PulseableLayer {
+open class Button: UIButton, Pulseable, PulseableLayer, Themeable {
   /**
    A CAShapeLayer used to manage elements that would be affected by
    the clipToBounds property of the backing layer. For example, this
@@ -281,7 +281,14 @@ open class Button: UIButton, Pulseable, PulseableLayer {
     contentScaleFactor = Screen.scale
     prepareVisualLayer()
     preparePulse()
+    applyCurrentTheme()
   }
+  
+  /**
+   Applies given theme to the view.
+   - Parameter theme: A Theme.
+  */
+  open func apply(theme: Theme) { }
 }
 
 extension Button {

--- a/Sources/iOS/Button.swift
+++ b/Sources/iOS/Button.swift
@@ -285,9 +285,9 @@ open class Button: UIButton, Pulseable, PulseableLayer, Themeable {
   }
   
   /**
-   Applies given theme to the view.
+   Applies the given theme.
    - Parameter theme: A Theme.
-  */
+   */
   open func apply(theme: Theme) { }
 }
 

--- a/Sources/iOS/CheckButton.swift
+++ b/Sources/iOS/CheckButton.swift
@@ -31,6 +31,12 @@ open class CheckButton: BaseIconLayerButton {
         guard !isAnimating else { return }
         setSelected(!isSelected, animated: true)
     }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    checkmarkColor = theme.onSecondary
+  }
 }
 
 internal class CheckBoxLayer: BaseIconLayer {
@@ -86,6 +92,7 @@ internal class CheckBoxLayer: BaseIconLayer {
         if isSelected {
             borderLayer.borderWidth = borderLayerNormalBorderWidth
         } else {
+            borderLayer.borderWidth = 0
             borderLayer.backgroundColor = (isEnabled ? normalColor : disabledColor).cgColor
             checkMarkLeftLayer.strokeEnd = 1
             checkMarkRightLayer.strokeEnd = 1

--- a/Sources/iOS/Editor.swift
+++ b/Sources/iOS/Editor.swift
@@ -190,6 +190,10 @@ open class Editor: View, Themeable {
     layoutBottomLabel(label: detailLabel, verticalOffset: detailVerticalOffset)
   }
   
+  /**
+   Applies the given theme.
+   - Parameter theme: A Theme.
+   */
   open func apply(theme: Theme) {
     placeholderActiveColor = theme.secondary
     placeholderNormalColor = theme.onSurface.withAlphaComponent(0.38)

--- a/Sources/iOS/Editor.swift
+++ b/Sources/iOS/Editor.swift
@@ -210,15 +210,6 @@ open class Editor: View, Themeable {
   open override func resignFirstResponder() -> Bool {
     return textView.resignFirstResponder()
   }
-  
-  open override var inputAccessoryView: UIView? {
-    get {
-      return textView.inputAccessoryView
-    }
-    set(value) {
-      textView.inputAccessoryView = value
-    }
-  }
 }
 
 

--- a/Sources/iOS/Editor.swift
+++ b/Sources/iOS/Editor.swift
@@ -35,7 +35,7 @@ public enum EditorPlaceholderAnimation {
   case hidden
 }
 
-open class Editor: View {
+open class Editor: View, Themeable {
   /// Reference to textView.
   public let textView = TextView()
   
@@ -173,11 +173,14 @@ open class Editor: View {
   
   open override func prepare() {
     super.prepare()
+    backgroundColor = nil
     prepareDivider()
     prepareTextView()
     preparePlaceholderLabel()
     prepareDetailLabel()
     prepareNotificationHandlers()
+    
+    applyCurrentTheme()
   }
   
   open override func layoutSubviews() {
@@ -185,6 +188,17 @@ open class Editor: View {
     layoutPlaceholderLabel()
     layoutDivider()
     layoutBottomLabel(label: detailLabel, verticalOffset: detailVerticalOffset)
+  }
+  
+  open func apply(theme: Theme) {
+    placeholderActiveColor = theme.secondary
+    placeholderNormalColor = theme.onSurface.withAlphaComponent(0.38)
+    
+    dividerActiveColor = theme.secondary
+    dividerNormalColor = theme.onSurface.withAlphaComponent(0.12)
+    
+    detailColor = theme.onSurface.withAlphaComponent(0.38)
+    textView.tintColor = theme.secondary
   }
   
   @discardableResult

--- a/Sources/iOS/ErrorTextField.swift
+++ b/Sources/iOS/ErrorTextField.swift
@@ -93,4 +93,10 @@ open class ErrorTextField: TextField {
     super.layoutSubviews()
     layoutBottomLabel(label: errorLabel, verticalOffset: errorVerticalOffset)
   }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    errorColor = theme.error
+  }
 }

--- a/Sources/iOS/FABButton.swift
+++ b/Sources/iOS/FABButton.swift
@@ -36,6 +36,14 @@ open class FABButton: Button {
     depthPreset = .depth1
     shapePreset = .circle
     pulseAnimation = .centerWithBacking
-    backgroundColor = .white
+  }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    backgroundColor = theme.secondary
+    titleColor = theme.onSecondary
+    tintColor = theme.onSecondary
+    pulseColor = theme.onSecondary
   }
 }

--- a/Sources/iOS/FlatButton.swift
+++ b/Sources/iOS/FlatButton.swift
@@ -35,4 +35,13 @@ open class FlatButton: Button {
     super.prepare()
     cornerRadiusPreset = .cornerRadius1
   }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    backgroundColor = .clear
+    titleColor = theme.secondary
+    tintColor = theme.secondary
+    pulseColor = theme.secondary
+  }
 }

--- a/Sources/iOS/IconButton.swift
+++ b/Sources/iOS/IconButton.swift
@@ -35,4 +35,11 @@ open class IconButton: Button {
     super.prepare()
     pulseAnimation = .center
   }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    tintColor = theme.secondary
+    pulseColor = theme.secondary
+  }
 }

--- a/Sources/iOS/IconButton.swift
+++ b/Sources/iOS/IconButton.swift
@@ -30,7 +30,18 @@
 
 import UIKit
 
+public enum IconButtonThemingStyle {
+  /// Theming when background content is in background color.
+  case onBackground
+  
+  /// Theming when background content is in primary color.
+  case onPrimary
+}
+
 open class IconButton: Button {
+  /// A reference to IconButtonThemingStyle.
+  open var themingStyle = IconButtonThemingStyle.onBackground
+  
   open override func prepare() {
     super.prepare()
     pulseAnimation = .center
@@ -39,7 +50,13 @@ open class IconButton: Button {
   open override func apply(theme: Theme) {
     super.apply(theme: theme)
     
-    tintColor = theme.secondary
-    pulseColor = theme.secondary
+    switch themingStyle {
+    case .onBackground:
+      tintColor = theme.secondary
+      pulseColor = theme.secondary
+    case .onPrimary:
+      tintColor = theme.onPrimary
+      pulseColor = theme.onPrimary
+    }
   }
 }

--- a/Sources/iOS/Material+UIColor.swift
+++ b/Sources/iOS/Material+UIColor.swift
@@ -99,7 +99,11 @@ internal extension UIColor {
     return UIColor(red: newR, green: newG, blue: newB, alpha: newA)
   }
   
-  
+  /**
+   Adjusts brightness of the color by given value.
+   - Parameter by value: A CGFloat value.
+   - Returns: Adjusted color.
+   */
   func adjustingBrightness(by value: CGFloat) -> UIColor {
     var h: CGFloat = 0
     var s: CGFloat = 0
@@ -111,11 +115,13 @@ internal extension UIColor {
     return UIColor(hue: h, saturation: s, brightness: (b + value).clamp(0, 1), alpha: 1)
   }
   
+  /// A lighter version of the color.
   var lighter: UIColor {
-    return adjustingBrightness(by: 0.05)
+    return adjustingBrightness(by: 0.1)
   }
   
+  /// A darker version of the color.
   var darker: UIColor {
-    return adjustingBrightness(by: -0.05)
+    return adjustingBrightness(by: -0.1)
   }
 }

--- a/Sources/iOS/Material+UIColor.swift
+++ b/Sources/iOS/Material+UIColor.swift
@@ -62,3 +62,40 @@ public extension UIColor {
     self.init(argb: (0xff000000 as UInt32) | rgb)
   }
 }
+
+internal extension UIColor {
+  /// A tuple of the rgba components.
+  var components: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+    var r: CGFloat = 0
+    var g: CGFloat = 0
+    var b: CGFloat = 0
+    var a: CGFloat = 0
+    
+    getRed(&r, green: &g, blue: &b, alpha: &a)
+    
+    return (r, g, b, a)
+  }
+  
+  /**
+   Blends given coverColor over this color.
+   - Parameter with coverColor: A UIColor.
+   - Returns: Resultant color of blending.
+   */
+  func blend(with coverColor: UIColor) -> UIColor {
+    
+    /// Blends channels according to https://en.wikipedia.org/wiki/Alpha_compositing (see `over` operator).
+    func blendChannel(value: CGFloat, bValue: CGFloat, alpha: CGFloat, bAlpha: CGFloat) -> CGFloat {
+      return ((1 - alpha) * bValue * bAlpha + alpha * value) / (alpha + bAlpha * (1 - alpha))
+    }
+    
+    let (r, g, b, a) = coverColor.components
+    let (bR, bG, bB, bA) = components
+    
+    let newR = blendChannel(value: r, bValue: bR, alpha: a, bAlpha: bA)
+    let newG = blendChannel(value: g, bValue: bG, alpha: a, bAlpha: bA)
+    let newB = blendChannel(value: b, bValue: bB, alpha: a, bAlpha: bA)
+    let newA = a + bA * (1 - a)
+    
+    return UIColor(red: newR, green: newG, blue: newB, alpha: newA)
+  }
+}

--- a/Sources/iOS/Material+UIColor.swift
+++ b/Sources/iOS/Material+UIColor.swift
@@ -98,4 +98,24 @@ internal extension UIColor {
     
     return UIColor(red: newR, green: newG, blue: newB, alpha: newA)
   }
+  
+  
+  func adjustingBrightness(by value: CGFloat) -> UIColor {
+    var h: CGFloat = 0
+    var s: CGFloat = 0
+    var b: CGFloat = 0
+    var a: CGFloat = 0
+    
+    getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+    
+    return UIColor(hue: h, saturation: s, brightness: (b + value).clamp(0, 1), alpha: 1)
+  }
+  
+  var lighter: UIColor {
+    return adjustingBrightness(by: 0.05)
+  }
+  
+  var darker: UIColor {
+    return adjustingBrightness(by: -0.05)
+  }
 }

--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -30,7 +30,7 @@
 
 import UIKit
 
-open class NavigationBar: UINavigationBar {
+open class NavigationBar: UINavigationBar, Themeable {
   /// Will layout the view.
   open var willLayout: Bool {
     return 0 < bounds.width && 0 < bounds.height && nil != superview
@@ -168,7 +168,32 @@ open class NavigationBar: UINavigationBar {
     let image = UIImage()
     shadowImage = image
     setBackgroundImage(image, for: .default)
-    backgroundColor = .white
+    applyCurrentTheme()
+  }
+  
+  open func apply(theme: Theme) {
+    backgroundColor = theme.primary
+    items?.forEach {
+      apply(theme: theme, to: $0)
+    }
+  }
+  
+  private func apply(theme: Theme, to item: UINavigationItem) {
+    item.toolbar.backgroundColor = .clear
+    (item.toolbar.leftViews + item.toolbar.rightViews + item.toolbar.centerViews).compactMap { $0 as? IconButton }
+      .filter { $0.isThemingEnabled }
+      .forEach {
+        $0.tintColor = theme.onPrimary
+        $0.pulseColor = theme.onPrimary
+      }
+    
+    if !((item.titleLabel as? Themeable)?.isThemingEnabled == false) {
+      item.titleLabel.textColor = theme.onPrimary
+    }
+    
+    if !((item.detailLabel as? Themeable)?.isThemingEnabled == false) {
+      item.detailLabel.textColor = theme.onPrimary
+    }
   }
 }
 
@@ -182,8 +207,11 @@ internal extension NavigationBar {
       return
     }
     
+    if isThemingEnabled {
+      apply(theme: .current, to: item)
+    }
+    
     let toolbar = item.toolbar
-    toolbar.backgroundColor = .clear
     toolbar.interimSpace = interimSpace
     toolbar.contentEdgeInsets = contentEdgeInsets
     

--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -171,6 +171,10 @@ open class NavigationBar: UINavigationBar, Themeable {
     applyCurrentTheme()
   }
   
+  /**
+   Applies the given theme.
+   - Parameter theme: A Theme.
+   */
   open func apply(theme: Theme) {
     backgroundColor = theme.primary
     items?.forEach {
@@ -178,6 +182,11 @@ open class NavigationBar: UINavigationBar, Themeable {
     }
   }
   
+  /**
+   Applies the given theme to the navigation item.
+   - Parameter theme: A Theme.
+   - Parameter to item: A UINavigationItem.
+   */
   private func apply(theme: Theme, to item: UINavigationItem) {
     Theme.apply(theme: theme, to: item.toolbar)
     item.toolbar.backgroundColor = .clear

--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -179,21 +179,8 @@ open class NavigationBar: UINavigationBar, Themeable {
   }
   
   private func apply(theme: Theme, to item: UINavigationItem) {
+    Theme.apply(theme: theme, to: item.toolbar)
     item.toolbar.backgroundColor = .clear
-    (item.toolbar.leftViews + item.toolbar.rightViews + item.toolbar.centerViews).compactMap { $0 as? IconButton }
-      .filter { $0.isThemingEnabled }
-      .forEach {
-        $0.tintColor = theme.onPrimary
-        $0.pulseColor = theme.onPrimary
-      }
-    
-    if !((item.titleLabel as? Themeable)?.isThemingEnabled == false) {
-      item.titleLabel.textColor = theme.onPrimary
-    }
-    
-    if !((item.detailLabel as? Themeable)?.isThemingEnabled == false) {
-      item.detailLabel.textColor = theme.onPrimary
-    }
   }
 }
 

--- a/Sources/iOS/RaisedButton.swift
+++ b/Sources/iOS/RaisedButton.swift
@@ -35,6 +35,14 @@ open class RaisedButton: Button {
     super.prepare()
     depthPreset = .depth1
     cornerRadiusPreset = .cornerRadius1
-    backgroundColor = .white
+  }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    backgroundColor = theme.secondary
+    titleColor = theme.onSecondary
+    pulseColor = theme.onSecondary
+    tintColor = theme.onSecondary
   }
 }

--- a/Sources/iOS/StatusBarController.swift
+++ b/Sources/iOS/StatusBarController.swift
@@ -120,6 +120,12 @@ open class StatusBarController: TransitionController {
     super.prepare()
     prepareStatusBar()
   }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    statusBar.backgroundColor = theme.primary.darker
+  }
 }
 
 fileprivate extension StatusBarController {

--- a/Sources/iOS/Switch.swift
+++ b/Sources/iOS/Switch.swift
@@ -327,6 +327,10 @@ open class Switch: UIControl, Themeable {
     applyCurrentTheme()
   }
   
+  /**
+   Applies the given theme.
+   - Parameter theme: A Theme.
+   */
   open func apply(theme: Theme) {
     buttonOnColor = theme.secondary
     trackOnColor = theme.secondary.withAlphaComponent(0.60)

--- a/Sources/iOS/Switch.swift
+++ b/Sources/iOS/Switch.swift
@@ -59,7 +59,7 @@ public protocol SwitchDelegate {
   func switchDidChangeState(control: Switch, state: SwitchState)
 }
 
-open class Switch: UIControl {
+open class Switch: UIControl, Themeable {
   /// Will layout the view.
   open var willLayout: Bool {
     return 0 < bounds.width && 0 < bounds.height && nil != superview
@@ -200,32 +200,6 @@ open class Switch: UIControl {
     }
   }
   
-  /// Switch style.
-  open var switchStyle = SwitchStyle.dark {
-    didSet {
-      switch switchStyle {
-      case .light:
-        buttonOnColor = Color.blue.darken2
-        trackOnColor = Color.blue.lighten3
-        buttonOffColor = Color.blueGrey.lighten4
-        trackOffColor = Color.grey.lighten2
-        buttonOnDisabledColor = Color.grey.lighten2
-        trackOnDisabledColor = Color.grey.lighten2
-        buttonOffDisabledColor = Color.grey.lighten2
-        trackOffDisabledColor = Color.grey.lighten2
-      case .dark:
-        buttonOnColor = Color.blue.lighten1
-        trackOnColor = Color.blue.lighten2.withAlphaComponent(0.5)
-        buttonOffColor = Color.grey.lighten2
-        trackOffColor = Color.blueGrey.lighten4.withAlphaComponent(0.5)
-        buttonOnDisabledColor = Color.grey.darken3
-        trackOnDisabledColor = Color.grey.lighten1.withAlphaComponent(0.2)
-        buttonOffDisabledColor = Color.grey.darken3
-        trackOffDisabledColor = Color.grey.lighten1.withAlphaComponent(0.2)
-      }
-    }
-  }
-  
   /// Switch size.
   open var switchSize = SwitchSize.medium {
     didSet {
@@ -293,7 +267,6 @@ open class Switch: UIControl {
     super.init(frame: .zero)
     prepare()
     prepareSwitchState(state: state)
-    prepareSwitchStyle(style: style)
     prepareSwitchSize(size: size)
   }
   
@@ -356,8 +329,20 @@ open class Switch: UIControl {
     prepareTrack()
     prepareButton()
     prepareSwitchState()
-    prepareSwitchStyle()
     prepareSwitchSize()
+    applyCurrentTheme()
+  }
+  
+  open func apply(theme: Theme) {
+    buttonOnColor = theme.secondary
+    trackOnColor = theme.secondary.withAlphaComponent(0.60)
+    buttonOffColor = theme.surface.blend(with: theme.onSurface.withAlphaComponent(0.15).blend(with: theme.secondary.withAlphaComponent(0.06)))
+    trackOffColor = theme.onSurface.withAlphaComponent(0.12)
+    
+    buttonOnDisabledColor = theme.surface.blend(with: theme.onSurface.withAlphaComponent(0.15))
+    trackOnDisabledColor = theme.onSurface.withAlphaComponent(0.15)
+    buttonOffDisabledColor = buttonOnDisabledColor
+    trackOffDisabledColor = trackOnDisabledColor
   }
 }
 
@@ -562,15 +547,6 @@ fileprivate extension Switch {
    */
   func prepareSwitchState(state: SwitchState = .off) {
     updateSwitchState(state: state, animated: false, isTriggeredByUserInteraction: false)
-  }
-  
-  /**
-   Prepares the switchStyle property. This is used mainly to allow
-   init to set the state value and have an effect.
-   - Parameter style: The SwitchStyle to set.
-   */
-  func prepareSwitchStyle(style: SwitchStyle = .light) {
-    switchStyle = style
   }
   
   /**

--- a/Sources/iOS/Switch.swift
+++ b/Sources/iOS/Switch.swift
@@ -30,12 +30,6 @@
 
 import UIKit
 
-@objc(SwitchStyle)
-public enum SwitchStyle: Int {
-  case light
-  case dark
-}
-
 @objc(SwitchState)
 public enum SwitchState: Int {
   case on
@@ -261,7 +255,7 @@ open class Switch: UIControl, Themeable {
    - Parameter style: A SwitchStyle value.
    - Parameter size: A SwitchSize value.
    */
-  public init(state: SwitchState = .off, style: SwitchStyle = .dark, size: SwitchSize = .medium) {
+  public init(state: SwitchState = .off, size: SwitchSize = .medium) {
     track = UIView()
     button = FABButton()
     super.init(frame: .zero)

--- a/Sources/iOS/TabBar.swift
+++ b/Sources/iOS/TabBar.swift
@@ -614,6 +614,7 @@ internal extension TabBar {
    */
   func finishLineTransition(isAnimated: Bool = true) {
     line.motionViewTransition.finish(isAnimated: isAnimated)
+    line.transition([])
   }
 
   /**
@@ -622,6 +623,7 @@ internal extension TabBar {
    */
   func cancelLineTransition(isAnimated: Bool = true) {
     line.motionViewTransition.cancel(isAnimated: isAnimated)
+    line.transition([])
   }
 }
 

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -167,6 +167,7 @@ open class TabsController: TransitionController {
   /// The tabBar alignment.
   open var tabBarAlignment = TabBarAlignment.bottom {
     didSet {
+      updateTabBarAlignment()
       layoutSubviews()
     }
   }
@@ -326,10 +327,14 @@ fileprivate extension TabsController {
   
   /// Prepares the TabBar.
   func prepareTabBar() {
-    tabBar.lineAlignment = .bottom == tabBarAlignment ? .top : .bottom
-    tabBar.dividerAlignment = .bottom == tabBarAlignment ? .top : .bottom
     tabBar._delegate = self
     view.addSubview(tabBar)
+    updateTabBarAlignment()
+  }
+  
+  func updateTabBarAlignment() {
+    tabBar.lineAlignment = .bottom == tabBarAlignment ? .top : .bottom
+    tabBar.dividerAlignment = .bottom == tabBarAlignment ? .top : .bottom
   }
   
   /// Prepares the `tabBar.tabItems`.

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -327,6 +327,7 @@ fileprivate extension TabsController {
   /// Prepares the TabBar.
   func prepareTabBar() {
     tabBar.lineAlignment = .bottom == tabBarAlignment ? .top : .bottom
+    tabBar.dividerAlignment = .bottom == tabBarAlignment ? .top : .bottom
     tabBar._delegate = self
     view.addSubview(tabBar)
   }

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -238,7 +238,7 @@ open class TabsController: TransitionController {
     super.apply(theme: theme)
     
     switch tabBarThemingStyle {
-    case .auto where parent is NavigationController && tabBarAlignment == .top:
+    case .auto where (parent is NavigationController || parent is ToolbarController) && tabBarAlignment == .top:
       fallthrough
       
     case .primary:

--- a/Sources/iOS/TabsController.swift
+++ b/Sources/iOS/TabsController.swift
@@ -39,6 +39,12 @@ public enum TabBarAlignment: Int {
   case bottom
 }
 
+public enum TabBarThemingStyle {
+  case auto
+  case primary
+  case secondary
+}
+
 extension UIViewController {
   /// TabItem reference.
   @objc
@@ -165,6 +171,9 @@ open class TabsController: TransitionController {
     }
   }
   
+  /// The tabBar theming style.
+  open var tabBarThemingStyle = TabBarThemingStyle.auto
+  
   /**
    A UIPanGestureRecognizer property internally used for the interactive
    swipe.
@@ -218,10 +227,54 @@ open class TabsController: TransitionController {
     prepareTabBar()
     prepareTabItems()
     prepareSelectedIndexViewController()
+    applyCurrentTheme()
   }
   
   open override func transition(to viewController: UIViewController, completion: ((Bool) -> Void)?) {
     transition(to: viewController, isTriggeredByUserInteraction: false, completion: completion)
+  }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    switch tabBarThemingStyle {
+    case .auto where parent is NavigationController && tabBarAlignment == .top:
+      fallthrough
+      
+    case .primary:
+      applyPrimary(theme: theme)
+      
+    default:
+      applySecondary(theme: theme)
+    }
+  }
+}
+
+private extension TabsController {
+  /**
+   Applies theming taking primary color as base.
+   - Parameter theme: A Theme
+   */
+  func applyPrimary(theme: Theme) {
+    tabBar.lineColor = theme.onPrimary.withAlphaComponent(0.68)
+    tabBar.backgroundColor = theme.primary
+    tabBar.setTabItemsColor(theme.onPrimary, for: .normal)
+    tabBar.setTabItemsColor(theme.onPrimary, for: .selected)
+    tabBar.setTabItemsColor(theme.onPrimary, for: .highlighted)
+    tabBar.isDividerHidden = true
+  }
+  
+  /**
+   Applies theming taking secondary color as base.
+   - Parameter theme: A Theme
+   */
+  func applySecondary(theme: Theme) {
+    tabBar.lineColor = theme.secondary
+    tabBar.backgroundColor = theme.background
+    tabBar.setTabItemsColor(theme.onSurface.withAlphaComponent(0.60), for: .normal)
+    tabBar.setTabItemsColor(theme.secondary, for: .selected)
+    tabBar.setTabItemsColor(theme.secondary, for: .highlighted)
+    tabBar.dividerColor = theme.onSurface.withAlphaComponent(0.12)
   }
 }
 

--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -63,7 +63,7 @@ public protocol TextFieldDelegate: UITextFieldDelegate {
   optional func textField(textField: TextField, didClear text: String?)
 }
 
-open class TextField: UITextField {
+open class TextField: UITextField, Themeable {
   
   /// Minimum TextField text height.
   private let minimumTextHeight: CGFloat = 32
@@ -459,6 +459,21 @@ open class TextField: UITextField {
     prepareTargetHandlers()
     prepareTextAlignment()
     prepareRightView()
+    applyCurrentTheme()
+  }
+  
+  open func apply(theme: Theme) {
+    placeholderActiveColor = theme.secondary
+    placeholderNormalColor = theme.onSurface.withAlphaComponent(0.38)
+    
+    leftViewActiveColor = theme.secondary
+    leftViewNormalColor = theme.onSurface.withAlphaComponent(0.38)
+    
+    dividerActiveColor = theme.secondary
+    dividerNormalColor = theme.onSurface.withAlphaComponent(0.12)
+    
+    detailColor = theme.onSurface.withAlphaComponent(0.38)
+    textColor = theme.onSurface.withAlphaComponent(0.87)
   }
 }
 

--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -462,6 +462,10 @@ open class TextField: UITextField, Themeable {
     applyCurrentTheme()
   }
   
+  /**
+   Applies the given theme.
+   - Parameter theme: A Theme.
+   */
   open func apply(theme: Theme) {
     placeholderActiveColor = theme.secondary
     placeholderNormalColor = theme.onSurface.withAlphaComponent(0.38)

--- a/Sources/iOS/TextView.swift
+++ b/Sources/iOS/TextView.swift
@@ -356,6 +356,10 @@ open class TextView: UITextView, Themeable {
     fixTypingFont()
   }
   
+  /**
+   Applies the given theme.
+   - Parameter theme: A Theme.
+   */
   open func apply(theme: Theme) {
     textColor = theme.onSurface.withAlphaComponent(0.87)
     placeholderColor = theme.onSurface.withAlphaComponent(0.38)

--- a/Sources/iOS/TextView.swift
+++ b/Sources/iOS/TextView.swift
@@ -87,7 +87,7 @@ public protocol TextViewDelegate : UITextViewDelegate {
   optional func textView(textView: TextView, didProcessEditing textStorage: TextStorage, text: String, range: NSRange)
 }
 
-open class TextView: UITextView {
+open class TextView: UITextView, Themeable {
   /// A boolean indicating whether the text is empty.
   open var isEmpty: Bool {
     return 0 == text?.utf16.count
@@ -289,6 +289,7 @@ open class TextView: UITextView {
     prepareNotificationHandlers()
     prepareRegularExpression()
     preparePlaceholderLabel()
+    applyCurrentTheme()
   }
   
   open override var contentSize: CGSize {
@@ -353,6 +354,11 @@ open class TextView: UITextView {
     fixTypingFont()
     super.paste(sender)
     fixTypingFont()
+  }
+  
+  open func apply(theme: Theme) {
+    textColor = theme.onSurface.withAlphaComponent(0.87)
+    placeholderColor = theme.onSurface.withAlphaComponent(0.38)
   }
 }
 

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -120,11 +120,11 @@ public extension Theme {
       return
     }
     
-    (view as? Themeable)?.apply(theme: theme)
-    
     view.subviews.forEach {
       apply(theme: theme, to: $0)
     }
+    
+    (view as? Themeable)?.apply(theme: theme)
   }
   
   /**
@@ -137,12 +137,12 @@ public extension Theme {
       return
     }
     
-    apply(theme: theme, to: viewController.view)
-    (viewController as? Themeable)?.apply(theme: theme)
-    
     viewController.children.forEach {
       apply(theme: theme, to: $0)
     }
+    
+    apply(theme: theme, to: viewController.view)
+    (viewController as? Themeable)?.apply(theme: theme)
   }
   
   /**
@@ -161,7 +161,7 @@ public extension Theme {
 
 
 /// A memory reference to the isThemingEnabled for Themeable NSObject subclasses.
-fileprivate var IsThemingEnabledKey: UInt8 = 0
+private var IsThemingEnabledKey: UInt8 = 0
 
 public extension Themeable where Self: NSObject {
   /// A boolean indicating if theming is enabled.

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -118,7 +118,7 @@ public extension Theme {
    - Parameter to view: A UIView.
    */
   static func apply(theme: Theme, to view: UIView) {
-    guard !((view as? Themeable)?.isThemingEnabled == false) else {
+    guard !((view as? Themeable)?.isThemingEnabled == false), !view.isProcessed else {
       return
     }
     
@@ -141,9 +141,15 @@ public extension Theme {
     
     viewController.children.forEach {
       apply(theme: theme, to: $0)
+      $0.view.isProcessed = true
     }
     
     apply(theme: theme, to: viewController.view)
+    
+    viewController.children.forEach {
+      $0.view.isProcessed = false
+    }
+    
     (viewController as? Themeable)?.apply(theme: theme)
   }
   
@@ -185,5 +191,22 @@ public extension Themeable where Self: NSObject {
     }
     
     apply(theme: .current)
+  }
+}
+
+/// A memory reference to the isProcessed for UIView.
+private var IsProcessedKey: UInt8 = 0
+
+private extension UIView {
+  /// A boolean indicating if view is already themed.
+  var isProcessed: Bool {
+    get {
+      return AssociatedObject.get(base: self, key: &IsProcessedKey) {
+        false
+      }
+    }
+    set(value) {
+      AssociatedObject.set(base: self, key: &IsProcessedKey, value: value)
+    }
   }
 }

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -102,11 +102,11 @@ public extension Theme {
    - Parameter theme: A Theme.
    */
   static func apply(theme: Theme) {
+    current = theme
     guard let v = Application.rootViewController else {
       return
     }
     
-    current = theme
     apply(theme: theme, to: v)
   }
   

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -70,15 +70,7 @@ public struct Theme {
 
 public extension Theme {
   /// Current theme for Material.
-  static var current = Theme.light {
-    didSet {
-      guard let v = Application.rootViewController else {
-        return
-      }
-      
-      apply(theme: .current, to: v)
-    }
-  }
+  static private(set) var current = Theme.light
   
   /// A light theme.
   static var light = Theme()
@@ -92,6 +84,21 @@ public extension Theme {
     t.onBackground = .white
     return t
   }()
+}
+
+public extension Theme {
+  /**
+   Applies theme to the entire app.
+   - Parameter theme: A Theme.
+   */
+  static func apply(theme: Theme) {
+    guard let v = Application.rootViewController else {
+      return
+    }
+    
+    current = theme
+    apply(theme: theme, to: v)
+  }
   
   /**
    Applies theme to the hierarchy of given view.

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -89,9 +89,10 @@ public extension Theme {
   static var dark: Theme = {
     var t = Theme()
     t.primary = UIColor(rgb: 0x202020)
-    t.secondary = UIColor(rgb: 0x33776B)
+    t.secondary = Color.teal.base
     t.background = UIColor(rgb: 0x303030)
     t.onBackground = .white
+    t.onSurface = .white
     return t
   }()
 }
@@ -174,5 +175,14 @@ public extension Themeable where Self: NSObject {
     set(value) {
       AssociatedObject.set(base: self, key: &IsThemingEnabledKey, value: value)
     }
+  }
+  
+  /// Applies current theme to itself if theming is enabled.
+  internal func applyCurrentTheme() {
+    guard isThemingEnabled else {
+      return
+    }
+    
+    apply(theme: .current)
   }
 }

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -32,7 +32,14 @@ import UIKit
 import Motion
 
 public protocol Themeable {
+  /**
+   Applies given theme.
+   - Parameter theme: A Theme.
+   */
   func apply(theme: Theme)
+  
+  /// A boolean indicating if theming is enabled.
+  var isThemingEnabled: Bool { get set }
 }
 
 public struct Theme {
@@ -109,6 +116,10 @@ public extension Theme {
    - Parameter to view: A UIView.
    */
   static func apply(theme: Theme, to view: UIView) {
+    guard !((view as? Themeable)?.isThemingEnabled == false) else {
+      return
+    }
+    
     (view as? Themeable)?.apply(theme: theme)
     
     view.subviews.forEach {
@@ -122,6 +133,10 @@ public extension Theme {
    - Parameter to viewController: A UIViewController.
    */
   static func apply(theme: Theme, to viewController: UIViewController) {
+    guard !((viewController as? Themeable)?.isThemingEnabled == false) else {
+      return
+    }
+    
     apply(theme: theme, to: viewController.view)
     (viewController as? Themeable)?.apply(theme: theme)
     
@@ -141,5 +156,23 @@ public extension Theme {
     current = theme
     execute()
     current = v
+  }
+}
+
+
+/// A memory reference to the isThemingEnabled for Themeable NSObject subclasses.
+fileprivate var IsThemingEnabledKey: UInt8 = 0
+
+public extension Themeable where Self: NSObject {
+  /// A boolean indicating if theming is enabled.
+  var isThemingEnabled: Bool {
+    get {
+      return AssociatedObject.get(base: self, key: &IsThemingEnabledKey) {
+        true
+      }
+    }
+    set(value) {
+      AssociatedObject.set(base: self, key: &IsThemingEnabledKey, value: value)
+    }
   }
 }

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -129,4 +129,17 @@ public extension Theme {
       apply(theme: theme, to: $0)
     }
   }
+  
+  /**
+   Applies provided theme for the components created within the given block
+   without chaging app's theme.
+   - Parameter theme: A Theme.
+   - Parameter for block: A code block.
+   */
+  static func applying(theme: Theme, for execute: () -> Void) {
+    let v = current
+    current = theme
+    execute()
+    current = v
+  }
 }

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -31,7 +31,7 @@
 import UIKit
 import Motion
 
-public protocol Themeable {
+public protocol Themeable: class {
   /**
    Applies given theme.
    - Parameter theme: A Theme.

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -42,9 +42,9 @@ public protocol Themeable: class {
   var isThemingEnabled: Bool { get set }
 }
 
-public struct Theme {
+public struct Theme: Hashable {
   /// The color displayed most frequently across the app.
-  public var primary = Color.blue.base
+  public var primary = Color.blue.darken2
   
   /// Accent color for some components such as FABMenu.
   public var secondary = Color.blue.base

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -139,14 +139,14 @@ public extension Theme {
       return
     }
     
-    viewController.children.forEach {
+    viewController.allChildren.forEach {
       apply(theme: theme, to: $0)
       $0.view.isProcessed = true
     }
     
     apply(theme: theme, to: viewController.view)
     
-    viewController.children.forEach {
+    viewController.allChildren.forEach {
       $0.view.isProcessed = false
     }
     
@@ -191,6 +191,23 @@ public extension Themeable where Self: NSObject {
     }
     
     apply(theme: .current)
+  }
+}
+
+private extension UIViewController {
+  /// Returns all possible child view controllers.
+  var allChildren: [UIViewController] {
+    var all = children
+    
+    if let v = self as? TabsController {
+      all += v.viewControllers
+    }
+    
+    if let v = presentedViewController, v.presentingViewController === self {
+      all.append(v)
+    }
+    
+    return all
   }
 }
 

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -66,6 +66,9 @@ public struct Theme {
   
   /// Text and iconography color to be used on error color.
   public var onError = Color.white
+  
+  /// An initializer.
+  public init() { }
 }
 
 public extension Theme {

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2015 - 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import UIKit
+import Motion
+
+public protocol Themeable {
+  func apply(theme: Theme)
+}
+
+public struct Theme {
+  /// The color displayed most frequently across the app.
+  public var primary = Color.blue.base
+  
+  /// Accent color for some components such as FABMenu.
+  public var secondary = Color.blue.base
+  
+  /// Background color for view controllers and some components.
+  public var background = Color.white
+  
+  /// Background color for components such as cards, and dialogs.
+  public var surface = Color.white
+  
+  /// Error color for components such as ErrorTextField.
+  public var error = Color.red.base
+  
+  
+  /// Text and iconography color to be used on primary color.
+  public var onPrimary = Color.white
+  
+  /// Text and iconography color to be used on secondary color.
+  public var onSecondary = Color.white
+  
+  /// Text and iconography color to be used on background color.
+  public var onBackground = Color.black
+  
+  /// Text and iconography color to be used on surface color.
+  public var onSurface = Color.black
+  
+  /// Text and iconography color to be used on error color.
+  public var onError = Color.white
+}
+
+public extension Theme {
+  /// Current theme for Material.
+  static var current = Theme.light {
+    didSet {
+      guard let v = Application.rootViewController else {
+        return
+      }
+      
+      apply(theme: .current, to: v)
+    }
+  }
+  
+  /// A light theme.
+  static var light = Theme()
+  
+  /// A dark theme.
+  static var dark: Theme = {
+    var t = Theme()
+    t.primary = UIColor(rgb: 0x202020)
+    t.secondary = UIColor(rgb: 0x33776B)
+    t.background = UIColor(rgb: 0x303030)
+    t.onBackground = .white
+    return t
+  }()
+  
+  /**
+   Applies theme to the hierarchy of given view.
+   - Parameter theme: A Theme.
+   - Parameter to view: A UIView.
+   */
+  static func apply(theme: Theme, to view: UIView) {
+    (view as? Themeable)?.apply(theme: theme)
+    
+    view.subviews.forEach {
+      apply(theme: theme, to: $0)
+    }
+  }
+  
+  /**
+   Applies theme to the hierarchy of given view controller.
+   - Parameter theme: A Theme.
+   - Parameter to viewController: A UIViewController.
+   */
+  static func apply(theme: Theme, to viewController: UIViewController) {
+    apply(theme: theme, to: viewController.view)
+    (viewController as? Themeable)?.apply(theme: theme)
+    
+    viewController.children.forEach {
+      apply(theme: theme, to: $0)
+    }
+  }
+}

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -91,6 +91,7 @@ public extension Theme {
     t.primary = UIColor(rgb: 0x202020)
     t.secondary = Color.teal.base
     t.background = UIColor(rgb: 0x303030)
+    t.surface = t.background
     t.onBackground = .white
     t.onSurface = .white
     return t

--- a/Sources/iOS/Toolbar.swift
+++ b/Sources/iOS/Toolbar.swift
@@ -30,7 +30,7 @@
 
 import UIKit
 
-open class Toolbar: Bar {
+open class Toolbar: Bar, Themeable {
   /// A convenience property to set the titleLabel.text.
   @IBInspectable
   open var title: String? {
@@ -62,6 +62,24 @@ open class Toolbar: Bar {
   /// Detail label.
   @IBInspectable
   public let detailLabel = UILabel()
+  
+  open override var leftViews: [UIView] {
+    didSet {
+      prepareIconButtons(leftViews)
+    }
+  }
+  
+  open override var centerViews: [UIView] {
+    didSet {
+      prepareIconButtons(centerViews)
+    }
+  }
+  
+  open override var rightViews: [UIView] {
+    didSet {
+      prepareIconButtons(rightViews)
+    }
+  }
   
   /**
    An initializer that initializes the object with a NSCoder object.
@@ -129,6 +147,25 @@ open class Toolbar: Bar {
     prepareDetailLabel()
   }
   
+  open func apply(theme: Theme) {
+    backgroundColor = theme.primary
+    (leftViews + rightViews + centerViews).forEach {
+      guard let v = $0 as? IconButton, v.isThemingEnabled else {
+        return
+      }
+      
+     v.apply(theme: theme)
+    }
+    
+    if !((titleLabel as? Themeable)?.isThemingEnabled == false) {
+      titleLabel.textColor = theme.onPrimary
+    }
+    
+    if !((detailLabel as? Themeable)?.isThemingEnabled == false) {
+      detailLabel.textColor = theme.onPrimary
+    }
+  }
+  
   /// A reference to titleLabel.textAlignment observation.
   private var titleLabelTextAlignmentObserver: NSKeyValueObservation!
 }
@@ -151,5 +188,13 @@ private extension Toolbar {
     detailLabel.contentScaleFactor = Screen.scale
     detailLabel.font = RobotoFont.regular(with: 12)
     detailLabel.textColor = Color.darkText.secondary
+  }
+  
+  func prepareIconButtons(_ views: [UIView]) {
+    views.forEach {
+      ($0 as? IconButton)?.themingStyle = .onPrimary
+    }
+    
+    applyCurrentTheme()
   }
 }

--- a/Sources/iOS/Toolbar.swift
+++ b/Sources/iOS/Toolbar.swift
@@ -147,6 +147,10 @@ open class Toolbar: Bar, Themeable {
     prepareDetailLabel()
   }
   
+  /**
+   Applies the given theme.
+   - Parameter theme: A Theme.
+   */
   open func apply(theme: Theme) {
     backgroundColor = theme.primary
     (leftViews + rightViews + centerViews).forEach {

--- a/Sources/iOS/ToolbarController.swift
+++ b/Sources/iOS/ToolbarController.swift
@@ -73,24 +73,6 @@ open class ToolbarController: StatusBarController {
     
     prepareToolbar()
   }
-  
-  open override func apply(theme: Theme) {
-    super.apply(theme: theme)
-    
-    toolbar.backgroundColor = theme.primary
-    toolbar.titleLabel.textColor = theme.onPrimary
-    toolbar.detailLabel.textColor = theme.onPrimary
-    
-    (toolbar.leftViews + toolbar.rightViews + toolbar.centerViews).compactMap {
-      $0 as? IconButton
-    }.filter {
-      $0.isThemingEnabled
-    }.forEach {
-      $0.tintColor = theme.onPrimary
-      $0.titleColor = theme.onPrimary
-      $0.pulseColor = theme.onPrimary
-    }
-  }
 }
 
 fileprivate extension ToolbarController {

--- a/Sources/iOS/ToolbarController.swift
+++ b/Sources/iOS/ToolbarController.swift
@@ -73,6 +73,24 @@ open class ToolbarController: StatusBarController {
     
     prepareToolbar()
   }
+  
+  open override func apply(theme: Theme) {
+    super.apply(theme: theme)
+    
+    toolbar.backgroundColor = theme.primary
+    toolbar.titleLabel.textColor = theme.onPrimary
+    toolbar.detailLabel.textColor = theme.onPrimary
+    
+    (toolbar.leftViews + toolbar.rightViews + toolbar.centerViews).compactMap {
+      $0 as? IconButton
+    }.filter {
+      $0.isThemingEnabled
+    }.forEach {
+      $0.tintColor = theme.onPrimary
+      $0.titleColor = theme.onPrimary
+      $0.pulseColor = theme.onPrimary
+    }
+  }
 }
 
 fileprivate extension ToolbarController {

--- a/Sources/iOS/ViewController.swift
+++ b/Sources/iOS/ViewController.swift
@@ -30,7 +30,7 @@
 
 import UIKit
 
-open class ViewController: UIViewController {
+open class ViewController: UIViewController, Themeable {
   open override func viewDidLoad() {
     super.viewDidLoad()
     prepare()
@@ -45,8 +45,8 @@ open class ViewController: UIViewController {
    */
   open func prepare() {
     view.clipsToBounds = true
-    view.backgroundColor = .white
     view.contentScaleFactor = Screen.scale
+    applyCurrentTheme()
   }
   
   open override func viewWillLayoutSubviews() {
@@ -61,4 +61,12 @@ open class ViewController: UIViewController {
    have a certain need.
    */
   open func layoutSubviews() { }
+  
+  /**
+   Applies given theme to the view controller.
+   - Parameter theme: A Theme.
+   */
+  open func apply(theme: Theme) {
+    view.backgroundColor = theme.background
+  }
 }


### PR DESCRIPTION
## General
Both views and viewControllers can be themed in Material:
* Views:
  * TextField
  * RaisedButton

* ViewControllers:
  * BottomNavigationController
  * StatusBarController

## How to use
Setting `Theme` for the app.
```swift
let appTheme = Theme()
appTheme.primary = Color.green.base
Theme.apply(theme: appTheme)
```
Getting current `Theme` object.
```swift
let currentTheme = Theme.current // current theme of the app
```

Material has 2 themes built in. Light and dark:
```swift
Theme.apply(theme: .dark) // Set dark theme for the app
Theme.apply(theme: .light) // Set light theme for the app (default)
```

Created `Themeable` views will be immediately themed with the `Theme.current`.
```swift
Theme.apply(theme: .light)
let lightThemedButton = RaisedButton()

Theme.apply(theme: .dark)
let darkThemedButton = RaisedButton()
```
### Disabling theming
Theming may (sometimes) override previously set colors. In such cases, you can use `isThemingEnabled` to disable theming for the a view (including its subviews).
```swift
let button = IconButton()
button.isThemingEnabled = false
button.tintColor = Color.red
navigationItem.rightViews = [button] // would override tintColor if theming was not disabled 
```

### More
Setting theme for the a specific view or viewController hierarchy:
```swift
// Views
myView.apply(theme: .dark) // Apply dark theme to myView (ignores isThemingEnabled)
Theme.apply(theme: .dark, to: myView) // Apply dark theme to myView and its subviews (respects isThemingEnabled)

// ViewControllers
viewController.apply(theme: .dark) // Apply dark theme to viewController (ignores isThemingEnabled)
Theme.apply(theme: .dark, to: viewController) // Apply dark theme to viewController (including views) and its children (respects isThemingEnabled)
```

## Sample
Here is sample app to test theming out. [Button.zip](https://github.com/CosmicMind/Material/files/2470125/Button.zip)

Double tap on background to change theme.

<img src="https://user-images.githubusercontent.com/15037839/46827788-9a337c80-cdaa-11e8-9e8a-df1e03c24399.gif" width="50%"/>


