### PR TITLE
ViewController-oriented clean up

### DIFF
--- a/Material.xcodeproj/project.pbxproj
+++ b/Material.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		96F1A5531F24F17A001D8CAF /* TabsController.swift in Headers */ = {isa = PBXBuildFile; fileRef = 96E09DC71F2287E50000B121 /* TabsController.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		9D054A6520D175AC00D0528D /* Material+UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D054A6320D175AC00D0528D /* Material+UIButton.swift */; };
 		9D054A6620D175AC00D0528D /* Material+UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D054A6420D175AC00D0528D /* Material+UILabel.swift */; };
+		9D39A81B20FE8ED100BA8FA1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D39A81A20FE8ED100BA8FA1 /* ViewController.swift */; };
 		9DE84D721FF0252600586C8B /* RadioButtonGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE84D6F1FF0252500586C8B /* RadioButtonGroup.swift */; };
 		9DE84D731FF0252600586C8B /* BaseButtonGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE84D701FF0252500586C8B /* BaseButtonGroup.swift */; };
 		9DE84D741FF0252600586C8B /* CheckButtonGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE84D711FF0252500586C8B /* CheckButtonGroup.swift */; };
@@ -295,6 +296,7 @@
 		96F1DC871D654FDF0025F925 /* Material+CALayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Material+CALayer.swift"; sourceTree = "<group>"; };
 		9D054A6320D175AC00D0528D /* Material+UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Material+UIButton.swift"; sourceTree = "<group>"; };
 		9D054A6420D175AC00D0528D /* Material+UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Material+UILabel.swift"; sourceTree = "<group>"; };
+		9D39A81A20FE8ED100BA8FA1 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		9DE84D6F1FF0252500586C8B /* RadioButtonGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RadioButtonGroup.swift; sourceTree = "<group>"; };
 		9DE84D701FF0252500586C8B /* BaseButtonGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseButtonGroup.swift; sourceTree = "<group>"; };
 		9DE84D711FF0252500586C8B /* CheckButtonGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckButtonGroup.swift; sourceTree = "<group>"; };
@@ -722,6 +724,7 @@
 			isa = PBXGroup;
 			children = (
 				96BCB78C1CB40DC500C806FE /* View.swift */,
+				9D39A81A20FE8ED100BA8FA1 /* ViewController.swift */,
 				96BCB7841CB40DC500C806FE /* PulseView.swift */,
 			);
 			name = View;
@@ -1012,6 +1015,7 @@
 				965E80CD1DD4C50600D61E4B /* Button.swift in Sources */,
 				965E80CE1DD4C50600D61E4B /* FABButton.swift in Sources */,
 				965E80CF1DD4C50600D61E4B /* FlatButton.swift in Sources */,
+				9D39A81B20FE8ED100BA8FA1 /* ViewController.swift in Sources */,
 				965E80D01DD4C50600D61E4B /* RaisedButton.swift in Sources */,
 				9DF58CEE20C098C60098968D /* ErrorTextFieldValidator.swift in Sources */,
 				9D054A6520D175AC00D0528D /* Material+UIButton.swift in Sources */,

--- a/Sources/iOS/BottomNavigationController.swift
+++ b/Sources/iOS/BottomNavigationController.swift
@@ -37,14 +37,7 @@ extension UIViewController {
    through child UIViewControllers.
    */
   public var bottomNavigationController: BottomNavigationController? {
-    var viewController: UIViewController? = self
-    while nil != viewController {
-      if viewController is BottomNavigationController {
-        return viewController as? BottomNavigationController
-      }
-      viewController = viewController?.parent
-    }
-    return nil
+    return traverseViewControllerHierarchyForClassType()
   }
 }
 

--- a/Sources/iOS/CardCollectionViewController.swift
+++ b/Sources/iOS/CardCollectionViewController.swift
@@ -48,7 +48,7 @@ extension UIViewController {
   }
 }
 
-open class CardCollectionViewController: UIViewController {
+open class CardCollectionViewController: ViewController {
   /// A reference to a Reminder.
   open let collectionView = CollectionView()
   
@@ -57,32 +57,13 @@ open class CardCollectionViewController: UIViewController {
   /// An index of IndexPath to DataSourceItem.
   open var dataSourceItemsIndexPaths = [IndexPath: Any]()
   
-  open override func viewDidLoad() {
-    super.viewDidLoad()
-    prepare()
-  }
-  
-  open override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-    layoutSubviews()
-  }
-  
-  /**
-   Prepares the view instance when intialized. When subclassing,
-   it is recommended to override the prepareView method
-   to initialize property values and other setup operations.
-   The super.prepareView method should always be called immediately
-   when subclassing.
-   */
-  open func prepare() {
-    view.clipsToBounds = true
-    view.backgroundColor = .white
-    view.contentScaleFactor = Screen.scale
+  open override func prepare() {
+    super.prepare()
     prepareCollectionView()
   }
   
-  /// Calls the layout functions for the view heirarchy.
-  open func layoutSubviews() {
+  open override func layoutSubviews() {
+    super.layoutSubviews()
     layoutCollectionView()
   }
 }

--- a/Sources/iOS/CardCollectionViewController.swift
+++ b/Sources/iOS/CardCollectionViewController.swift
@@ -37,14 +37,7 @@ extension UIViewController {
    through child UIViewControllers.
    */
   public var cardCollectionViewController: CardCollectionViewController? {
-    var viewController: UIViewController? = self
-    while nil != viewController {
-      if viewController is CardCollectionViewController {
-        return viewController as? CardCollectionViewController
-      }
-      viewController = viewController?.parent
-    }
-    return nil
+    return traverseViewControllerHierarchyForClassType()
   }
 }
 

--- a/Sources/iOS/CollectionViewController.swift
+++ b/Sources/iOS/CollectionViewController.swift
@@ -51,38 +51,19 @@ extension UIViewController {
   }
 }
 
-open class CollectionViewController: UIViewController {
+open class CollectionViewController: ViewController {
   /// A reference to a Reminder.
   open let collectionView = CollectionView()
   
   open var dataSourceItems = [DataSourceItem]()
   
-  open override func viewDidLoad() {
-    super.viewDidLoad()
-    prepare()
-  }
-  
-  open override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-    layoutSubviews()
-  }
-  
-  /**
-   Prepares the view instance when intialized. When subclassing,
-   it is recommended to override the prepareView method
-   to initialize property values and other setup operations.
-   The super.prepareView method should always be called immediately
-   when subclassing.
-   */
-  open func prepare() {
-    view.clipsToBounds = true
-    view.backgroundColor = .white
-    view.contentScaleFactor = Screen.scale
+  open override func prepare() {
+    super.prepare()
     prepareCollectionView()
   }
   
-  /// Calls the layout functions for the view heirarchy.
-  open func layoutSubviews() {
+  open override func layoutSubviews() {
+    super.layoutSubviews()
     layoutCollectionView()
   }
 }

--- a/Sources/iOS/TableViewController.swift
+++ b/Sources/iOS/TableViewController.swift
@@ -58,29 +58,15 @@ extension UIViewController {
   }
 }
 
-open class TableViewController: UIViewController {
+open class TableViewController: ViewController {
   /// A reference to a Reminder.
   open let tableView = TableView()
   
   /// An Array of DataSourceItems.
   open var dataSourceItems = [DataSourceItem]()
   
-  open override func viewDidLoad() {
-    super.viewDidLoad()
-    prepare()
-  }
-  
-  /**
-   Prepares the view instance when intialized. When subclassing,
-   it is recommended to override the prepareView method
-   to initialize property values and other setup operations.
-   The super.prepareView method should always be called immediately
-   when subclassing.
-   */
-  open func prepare() {
-    view.clipsToBounds = true
-    view.backgroundColor = .white
-    view.contentScaleFactor = Screen.scale
+  open override func prepare() {
+    super.prepare()
     prepareTableView()
   }
 }

--- a/Sources/iOS/TableViewController.swift
+++ b/Sources/iOS/TableViewController.swift
@@ -47,14 +47,7 @@ extension UIViewController {
    through child UIViewControllers.
    */
   public var tableViewController: TableViewController? {
-    var viewController: UIViewController? = self
-    while nil != viewController {
-      if viewController is TableViewController {
-        return viewController as? TableViewController
-      }
-      viewController = viewController?.parent
-    }
-    return nil
+    return traverseViewControllerHierarchyForClassType()
   }
 }
 

--- a/Sources/iOS/TransitionController.swift
+++ b/Sources/iOS/TransitionController.swift
@@ -31,7 +31,7 @@
 import UIKit
 import Motion
 
-open class TransitionController: UIViewController {
+open class TransitionController: ViewController {
   /**
    A Boolean property used to enable and disable interactivity
    with the rootViewController.
@@ -100,11 +100,6 @@ open class TransitionController: UIViewController {
     return false
   }
   
-  open override func viewDidLoad() {
-    super.viewDidLoad()
-    prepare()
-  }
-  
   open override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     rootViewController.beginAppearanceTransition(true, animated: animated)
@@ -123,11 +118,6 @@ open class TransitionController: UIViewController {
   open override func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
     rootViewController.endAppearanceTransition()
-  }
-  
-  open override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-    layoutSubviews()
   }
   
   /**
@@ -163,24 +153,8 @@ open class TransitionController: UIViewController {
     }
   }
   
-  /**
-   To execute in the order of the layout chain, override this
-   method. `layoutSubviews` should be called immediately, unless you
-   have a certain need.
-   */
-  open func layoutSubviews() {}
-  
-  /**
-   Prepares the view instance when intialized. When subclassing,
-   it is recommended to override the prepare method
-   to initialize property values and other setup operations.
-   The super.prepare method should always be called immediately
-   when subclassing.
-   */
-  open func prepare() {
-    view.clipsToBounds = true
-    view.backgroundColor = .white
-    view.contentScaleFactor = Screen.scale
+  open override func prepare() {
+    super.prepare()
     
     prepareContainer()
     

--- a/Sources/iOS/ViewController.swift
+++ b/Sources/iOS/ViewController.swift
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 - 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import UIKit
+
+open class ViewController: UIViewController {
+  open override func viewDidLoad() {
+    super.viewDidLoad()
+    prepare()
+  }
+  
+  /**
+   Prepares the view instance when intialized. When subclassing,
+   it is recommended to override the prepareView method
+   to initialize property values and other setup operations.
+   The super.prepareView method should always be called immediately
+   when subclassing.
+   */
+  open func prepare() {
+    view.clipsToBounds = true
+    view.backgroundColor = .white
+    view.contentScaleFactor = Screen.scale
+  }
+  
+  open override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    layoutSubviews()
+  }
+  
+  /**
+   Calls the layout functions for the view heirarchy.
+   To execute in the order of the layout chain, override this
+   method. `layoutSubviews` should be called immediately, unless you
+   have a certain need.
+   */
+  open func layoutSubviews() { }
+}


### PR DESCRIPTION
Changes:
* There were some common code where `UIViewController` was subclassed, those are moved to new `ViewController` base class.
* `traverseViewControllerHierarchyForClassType()` method is used instead of manual lookup