### PR TITLE
 Fixed issue-1123, TextField is not scrolling

### DIFF
--- a/Material.podspec
+++ b/Material.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 	s.name = 'Material'
 	s.version = '2.17.0'
-	s.swift_version = '4.0'
+	s.swift_version = '4.2'
 	s.license = 'BSD-3-Clause'
 	s.summary = 'A UI/UX framework for creating beautiful applications.'
 	s.homepage = 'http://cosmicmind.com'
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
 			'com.cosmicmind.material.fonts' => ['Sources/**/*.ttf']
 		}
 
-		s.dependency 'Motion', '~> 1.4.3'
+		s.dependency 'Motion', '~> 1.5.0'
 	end
 end

--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -66,7 +66,7 @@ public protocol TextFieldDelegate: UITextFieldDelegate {
 open class TextField: UITextField {
   /// Default size when using AutoLayout.
   open override var intrinsicContentSize: CGSize {
-    return CGSize(width: bounds.width, height: 32)
+    return CGSize(width: bounds.width, height: max(32, super.intrinsicContentSize.height))
   }
   
   /// A Boolean that indicates if the placeholder label is animated.


### PR DESCRIPTION
Fixed issue #1123, which was caused by returning `height: 32`  for `intrinsicContentSize`. Which was causing issues and a bad ui when a huge font size is used. Fixed by calculating height as `max(32, super.intrinsicContentSize.height)` instead of just `32`.

Before fix:
![](https://user-images.githubusercontent.com/15037839/43483876-d98f3b5a-951d-11e8-95ef-1eb2b1fada41.gif)

After fix:
![](https://user-images.githubusercontent.com/15037839/43483789-a2911a92-951d-11e8-846e-02908dc1baef.gif)


Fixed issue #1122 as well, updated `Material.podspec`