### PR TITLE
New features

### DIFF
--- a/Sources/iOS/BottomNavigationController.swift
+++ b/Sources/iOS/BottomNavigationController.swift
@@ -41,11 +41,11 @@ extension UIViewController {
   }
 }
 
-private class MaterialTabBar: UITabBar{
+private class MaterialTabBar: UITabBar {
   override func sizeThatFits(_ size: CGSize) -> CGSize {
     var v = super.sizeThatFits(size)
-    let offset = v.height - 49
-    v.height = CGFloat(heightPreset.rawValue) + offset
+    let offset = v.height - HeightPreset.normal.rawValue
+    v.height = heightPreset.rawValue + offset
     return v
   }
 }

--- a/Sources/iOS/BottomNavigationController.swift
+++ b/Sources/iOS/BottomNavigationController.swift
@@ -41,6 +41,15 @@ extension UIViewController {
   }
 }
 
+private class MaterialTabBar: UITabBar{
+  override func sizeThatFits(_ size: CGSize) -> CGSize {
+    var v = super.sizeThatFits(size)
+    let offset = v.height - 49
+    v.height = CGFloat(heightPreset.rawValue) + offset
+    return v
+  }
+}
+
 open class BottomNavigationController: UITabBarController {
   /// A Boolean that indicates if the swipe feature is enabled..
   open var isSwipeEnabled = false {
@@ -60,6 +69,7 @@ open class BottomNavigationController: UITabBarController {
    */
   public required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
+    setTabBarClass()
   }
   
   /**
@@ -69,6 +79,7 @@ open class BottomNavigationController: UITabBarController {
    */
   public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    setTabBarClass()
   }
   
   /// An initializer that accepts no parameters.
@@ -140,6 +151,17 @@ open class BottomNavigationController: UITabBarController {
     view.contentScaleFactor = Screen.scale
     
     prepareTabBar()
+  }
+}
+
+private extension BottomNavigationController {
+  /// Sets tabBar class to MaterialTabBar.
+  func setTabBarClass() {
+    guard object_getClass(tabBar) === UITabBar.self else {
+      return
+    }
+    
+    object_setClass(tabBar, MaterialTabBar.self)
   }
 }
 

--- a/Sources/iOS/Depth.swift
+++ b/Sources/iOS/Depth.swift
@@ -42,16 +42,17 @@ public enum DepthPreset {
   indirect case left(DepthPreset)
   indirect case right(DepthPreset)
   
-  public var root: DepthPreset {
+  /// Returns raw depth value without considering direction.
+  public var rawValue: DepthPreset {
     switch self {
     case .above(let v):
-      return v.root
+      return v.rawValue
     case .below(let v):
-      return v.root
+      return v.rawValue
     case .left(let v):
-      return v.root
+      return v.rawValue
     case .right(let v):
-      return v.root
+      return v.rawValue
     default:
       return self
     }
@@ -133,8 +134,8 @@ public func DepthPresetToValue(preset: DepthPreset) -> Depth {
     if preset.isRoot {
       v.offset.vertical *= -1
     } else {
-      let root = DepthPresetToValue(preset: preset.root)
-      v.offset.vertical -= root.offset.vertical
+      let value = DepthPresetToValue(preset: preset.rawValue)
+      v.offset.vertical -= value.offset.vertical
     }
     return v
   case .below(let preset):
@@ -142,8 +143,8 @@ public func DepthPresetToValue(preset: DepthPreset) -> Depth {
     if preset.isRoot {
       return v
     } else {
-      let root = DepthPresetToValue(preset: preset.root)
-      v.offset.vertical += root.offset.vertical
+      let value = DepthPresetToValue(preset: preset.rawValue)
+      v.offset.vertical += value.offset.vertical
     }
     return v
   case .left(let preset):
@@ -152,8 +153,8 @@ public func DepthPresetToValue(preset: DepthPreset) -> Depth {
       v.offset.horizontal = -v.offset.vertical
       v.offset.vertical = 0
     } else {
-      let root = DepthPresetToValue(preset: preset.root)
-      v.offset.horizontal -= root.offset.vertical
+      let value = DepthPresetToValue(preset: preset.rawValue)
+      v.offset.horizontal -= value.offset.vertical
     }
     return v
   case .right(let preset):
@@ -162,14 +163,15 @@ public func DepthPresetToValue(preset: DepthPreset) -> Depth {
       v.offset.horizontal = v.offset.vertical
       v.offset.vertical = 0
     } else {
-      let root = DepthPresetToValue(preset: preset.root)
-      v.offset.horizontal += root.offset.vertical
+      let value = DepthPresetToValue(preset: preset.rawValue)
+      v.offset.horizontal += value.offset.vertical
     }
     return v
   }
 }
 
 fileprivate extension DepthPreset {
+  /// Checks if the preset is the root value (has no direction).
   var isRoot: Bool {
     switch self {
     case .above(_):

--- a/Sources/iOS/Depth.swift
+++ b/Sources/iOS/Depth.swift
@@ -30,14 +30,32 @@
 
 import UIKit
 
-@objc(DepthPreset)
-public enum DepthPreset: Int {
+public enum DepthPreset {
   case none
   case depth1
   case depth2
   case depth3
   case depth4
   case depth5
+  indirect case above(DepthPreset)
+  indirect case below(DepthPreset)
+  indirect case left(DepthPreset)
+  indirect case right(DepthPreset)
+  
+  public var root: DepthPreset {
+    switch self {
+    case .above(let v):
+      return v.root
+    case .below(let v):
+      return v.root
+    case .left(let v):
+      return v.root
+    case .right(let v):
+      return v.root
+    default:
+      return self
+    }
+  }
 }
 
 public struct Depth {
@@ -110,5 +128,60 @@ public func DepthPresetToValue(preset: DepthPreset) -> Depth {
     return Depth(offset: Offset(horizontal: 0, vertical: 4), opacity: 0.3, radius: 4)
   case .depth5:
     return Depth(offset: Offset(horizontal: 0, vertical: 8), opacity: 0.3, radius: 8)
+  case .above(let preset):
+    var v = DepthPresetToValue(preset: preset)
+    if preset.isRoot {
+      v.offset.vertical *= -1
+    } else {
+      let root = DepthPresetToValue(preset: preset.root)
+      v.offset.vertical -= root.offset.vertical
+    }
+    return v
+  case .below(let preset):
+    var v = DepthPresetToValue(preset: preset)
+    if preset.isRoot {
+      return v
+    } else {
+      let root = DepthPresetToValue(preset: preset.root)
+      v.offset.vertical += root.offset.vertical
+    }
+    return v
+  case .left(let preset):
+    var v = DepthPresetToValue(preset: preset)
+    if preset.isRoot {
+      v.offset.horizontal = -v.offset.vertical
+      v.offset.vertical = 0
+    } else {
+      let root = DepthPresetToValue(preset: preset.root)
+      v.offset.horizontal -= root.offset.vertical
+    }
+    return v
+  case .right(let preset):
+    var v = DepthPresetToValue(preset: preset)
+    if preset.isRoot {
+      v.offset.horizontal = v.offset.vertical
+      v.offset.vertical = 0
+    } else {
+      let root = DepthPresetToValue(preset: preset.root)
+      v.offset.horizontal += root.offset.vertical
+    }
+    return v
+  }
+}
+
+fileprivate extension DepthPreset {
+  var isRoot: Bool {
+    switch self {
+    case .above(_):
+      return false
+    case .below(_):
+      return false
+    case .left(_):
+      return false
+    case .right(_):
+      return false
+    default:
+      return true
+    }
   }
 }

--- a/Sources/iOS/HeightPreset.swift
+++ b/Sources/iOS/HeightPreset.swift
@@ -30,16 +30,43 @@
 
 import UIKit
 
-@objc(HeightPreset)
-public enum HeightPreset: Int {
-  case none = 0
-  case tiny = 20
-  case xsmall = 28
-  case small = 36
-  case `default` = 44
-  case normal = 49
-  case medium = 52
-  case large = 60
-  case xlarge = 68
-  case xxlarge = 104
+public enum HeightPreset {
+  case none
+  case tiny
+  case xsmall
+  case small
+  case `default`
+  case normal
+  case medium
+  case large
+  case xlarge
+  case xxlarge
+  case custom(CGFloat)
+  
+  public var rawValue: CGFloat {
+    switch self {
+    case .none:
+      return 0
+    case .tiny:
+      return 20
+    case .xsmall:
+      return 28
+    case .small:
+      return 36
+    case .`default`:
+      return 44
+    case .normal:
+      return 49
+    case .medium:
+      return 52
+    case .large:
+      return 60
+    case .xlarge:
+      return 68
+    case .xxlarge:
+      return 104
+    case .custom(let v):
+      return v
+    }
+  }
 }

--- a/Sources/iOS/Material+CALayer.swift
+++ b/Sources/iOS/Material+CALayer.swift
@@ -281,7 +281,7 @@ extension CALayer {
       return
     }
     
-    if case .none = depthPreset.root {
+    if case .none = depthPreset.rawValue {
       shadowPath = nil
     } else if nil == shadowPath {
       shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius).cgPath

--- a/Sources/iOS/Material+CALayer.swift
+++ b/Sources/iOS/Material+CALayer.swift
@@ -38,7 +38,7 @@ fileprivate class MaterialLayer {
   /// A property that sets the height of the layer's frame.
   fileprivate var heightPreset = HeightPreset.default {
     didSet {
-      layer?.height = CGFloat(heightPreset.rawValue)
+      layer?.height = heightPreset.rawValue
     }
   }
   

--- a/Sources/iOS/Material+CALayer.swift
+++ b/Sources/iOS/Material+CALayer.swift
@@ -281,7 +281,7 @@ extension CALayer {
       return
     }
     
-    if .none == depthPreset {
+    if case .none = depthPreset.root {
       shadowPath = nil
     } else if nil == shadowPath {
       shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius).cgPath

--- a/Sources/iOS/Material+UIView.swift
+++ b/Sources/iOS/Material+UIView.swift
@@ -61,7 +61,6 @@ extension UIView {
   }
   
   /// HeightPreset value.
-  @objc
   open var heightPreset: HeightPreset {
     get {
       return layer.heightPreset

--- a/Sources/iOS/Material+UIView.swift
+++ b/Sources/iOS/Material+UIView.swift
@@ -87,7 +87,6 @@ extension UIView {
   }
   
   /// A preset value for Depth.
-  @objc
   open var depthPreset: DepthPreset {
     get {
       return layer.depthPreset


### PR DESCRIPTION
#### Added `left/right/above/below` directions to `DepthPreset`.
We can now use, `depthPreset = .below(.right(.depth5)))` and get shadow cast below and right of the view. 
Using the same modifier twice just increases the offset:
```swift
depthPreset = .right(.right(.below(.below(.depth5)))))
```
Default is direction is `below`. 
```swift
depthPreset = .below(.depth5)
depthPreset = .depth5 // same as above
```
**Note:** Had to remove `@objc` to add this feature.

#### Added `.custom(x)` case for `HeightPreset`.
```swift
heightPreset = .custom(32.3)
```
**Note:** Had to remove `@objc` to add this feature.

#### Added support for `heightPreset` in `BottomNavigationController`.
Manipulating `tabBar.frame` was only working in `layoutSubviews()`. Using this way had drawbacks:
  1. `tabBar` height was returned back to default on rotation.
  2. `selectedViewController?.view.frame` was not changing even though it was calculated and set. (It should shrink as the tabBar grows occupying the space)

Fortunately, tabBar height is taken via `sizeThatFits` method, so I use `UITabBar` subclass returning custom height based on `heightPreset` value.

```swift
private class MaterialTabBar: UITabBar {
  override func sizeThatFits(_ size: CGSize) -> CGSize {
    var v = super.sizeThatFits(size)
    let offset = v.height - HeightPreset.normal.rawValue
    v.height = heightPreset.rawValue + offset
    return v
  }
}
```

`v.height - HeightPreset.normal.rawValue` calculates the offset of the system from our reference. It allows us to match system's behavior. 

Suppose `tabBar.heightPreset = .normal //rawValue is 49` and `super.sizeThatFits(size).height` returns `49`. In this case resulting height becomes `49`, if the system would return `83` or `58` (values are for iPhoneX's portrait and landscape orientation respectively), the resulting height would be the same. If we set `tabBar.heightPreset = .xxlarge` then for iPhoneX's portrait and landscape orientation the tabBar height would be `138` and `113` respectively. In portrait it has larger `tabBar` height than landscape, so behavior of the system is matched.


Related:
#1144, #1150