### PR TITLE
Fixed tab bar class was not set in some cases

### DIFF
--- a/Sources/iOS/BottomNavigationController.swift
+++ b/Sources/iOS/BottomNavigationController.swift
@@ -98,6 +98,7 @@ open class BottomNavigationController: UITabBarController {
   /// An initializer that accepts no parameters.
   public init() {
     super.init(nibName: nil, bundle: nil)
+    setTabBarClass()
   }
   
   /**
@@ -106,6 +107,7 @@ open class BottomNavigationController: UITabBarController {
    */
   public init(viewControllers: [UIViewController]) {
     super.init(nibName: nil, bundle: nil)
+    setTabBarClass()
     self.viewControllers = viewControllers
   }
   


### PR DESCRIPTION
2 initializers were missing `setTabBarClass`, added them.