### PR TITLE
Added disabling theming globally and per-class

### DIFF
--- a/Sources/iOS/NavigationBar.swift
+++ b/Sources/iOS/NavigationBar.swift
@@ -189,7 +189,6 @@ open class NavigationBar: UINavigationBar, Themeable {
    */
   private func apply(theme: Theme, to item: UINavigationItem) {
     Theme.apply(theme: theme, to: item.toolbar)
-    item.toolbar.backgroundColor = .clear
   }
 }
 
@@ -208,6 +207,7 @@ internal extension NavigationBar {
     }
     
     let toolbar = item.toolbar
+    toolbar.backgroundColor = .clear
     toolbar.interimSpace = interimSpace
     toolbar.contentEdgeInsets = contentEdgeInsets
     

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -74,6 +74,9 @@ public struct Theme: Hashable {
   /// Text and iconography color to be used on error color.
   public var onError = Color.white
   
+  /// A boolean indicating if theming is enabled globally.
+  public static var isEnabled = true
+  
   /// An initializer.
   public init() { }
 }
@@ -175,7 +178,7 @@ public extension Themeable where Self: NSObject {
   /// A class-wide boolean indicating if theming is enabled.
   static var isThemingEnabled: Bool {
     get {
-      return AssociatedObject.get(base: self, key: &IsThemingEnabledKey) {
+      return Theme.isEnabled && AssociatedObject.get(base: self, key: &IsThemingEnabledKey) {
         true
       }
     }

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -190,7 +190,7 @@ public extension Themeable where Self: NSObject {
   /// A boolean indicating if theming is enabled.
   var isThemingEnabled: Bool {
     get {
-      return Self.isThemingEnabled && AssociatedObject.get(base: self, key: &IsThemingEnabledKey) {
+      return type(of: self).isThemingEnabled && AssociatedObject.get(base: self, key: &IsThemingEnabledKey) {
         true
       }
     }

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -172,10 +172,22 @@ public extension Theme {
 private var IsThemingEnabledKey: UInt8 = 0
 
 public extension Themeable where Self: NSObject {
+  /// A class-wide boolean indicating if theming is enabled.
+  static var isThemingEnabled: Bool {
+    get {
+      return AssociatedObject.get(base: self, key: &IsThemingEnabledKey) {
+        true
+      }
+    }
+    set(value) {
+      AssociatedObject.set(base: self, key: &IsThemingEnabledKey, value: value)
+    }
+  }
+  
   /// A boolean indicating if theming is enabled.
   var isThemingEnabled: Bool {
     get {
-      return AssociatedObject.get(base: self, key: &IsThemingEnabledKey) {
+      return Self.isThemingEnabled && AssociatedObject.get(base: self, key: &IsThemingEnabledKey) {
         true
       }
     }


### PR DESCRIPTION
Added feature request https://github.com/CosmicMind/Material/pull/1115#issuecomment-430994737
```swift
Theme.isEnabled = false // disable globally
TextField.isThemingEnabled = false /// disable for the entire class
```