### PR TITLE
Manually invalidate NSKeyValueObservation to prevent iOS 10 crash

### DIFF
--- a/Sources/iOS/Editor.swift
+++ b/Sources/iOS/Editor.swift
@@ -170,7 +170,15 @@ open class Editor: View, Themeable {
    Only observes programmatic changes.
    */
   private var textViewTextObserver: NSKeyValueObservation!
-  
+
+  deinit {
+    placeholderLabelTextObserver.invalidate()
+    placeholderLabelTextObserver = nil
+
+    textViewTextObserver.invalidate()
+    textViewTextObserver = nil
+  }
+
   open override func prepare() {
     super.prepare()
     backgroundColor = nil

--- a/Sources/iOS/Toolbar.swift
+++ b/Sources/iOS/Toolbar.swift
@@ -80,7 +80,12 @@ open class Toolbar: Bar, Themeable {
       prepareIconButtons(rightViews)
     }
   }
-  
+
+  deinit {
+    titleLabelTextAlignmentObserver.invalidate()
+    titleLabelTextAlignmentObserver = nil
+  }
+
   /**
    An initializer that initializes the object with a NSCoder object.
    - Parameter aDecoder: A NSCoder instance.


### PR DESCRIPTION
On iOS 10, NSKeyValueObservation crashes during deinit.
This looks like a known issue, but for the moment we can resolve it using the provided workaround.

https://bugs.swift.org/browse/SR-5816
https://stackoverflow.com/questions/50058609/ios-10-nskeyvalueobservation-crash-on-deinit