### PR TITLE
Global font and navigationItem.backButton issue

### DIFF
--- a/Sources/iOS/Button.swift
+++ b/Sources/iOS/Button.swift
@@ -279,6 +279,7 @@ open class Button: UIButton, Pulseable, PulseableLayer, Themeable {
    */
   open func prepare() {
     contentScaleFactor = Screen.scale
+    titleLabel?.font = Theme.font.regular(with: fontSize)
     prepareVisualLayer()
     preparePulse()
     applyCurrentTheme()

--- a/Sources/iOS/DialogView.swift
+++ b/Sources/iOS/DialogView.swift
@@ -270,6 +270,7 @@ private extension DialogView {
   /// Prepares detailsLabel.
   func prepareDetailsLabel() {
     contentArea.addSubview(detailsLabel)
+    detailsLabel.font = Theme.font.regular(with: detailsLabel.fontSize)
     detailsLabel.numberOfLines = 0
     detailsLabel.textColor = Color.darkText.secondary
   }

--- a/Sources/iOS/DialogView.swift
+++ b/Sources/iOS/DialogView.swift
@@ -233,7 +233,7 @@ private extension DialogView {
   /// Prepares titleTitle.
   func prepareTitleLabel() {
     titleArea.addSubview(titleLabel)
-    titleLabel.font = RobotoFont.bold(with: 20)
+    titleLabel.font = Theme.font.bold(with: 20)
     titleLabel.textColor = Color.darkText.primary
     titleLabel.numberOfLines = 0
   }
@@ -250,7 +250,7 @@ private extension DialogView {
   func prepareButtons() {
     [positiveButton, negativeButton, neutralButton].forEach {
       buttonArea.addSubview($0)
-      $0.titleLabel?.font = RobotoFont.medium(with: 14)
+      $0.titleLabel?.font = Theme.font.medium(with: 14)
       $0.contentEdgeInsets = Constants.button.insets
       $0.cornerRadiusPreset = .cornerRadius1
     }

--- a/Sources/iOS/Editor.swift
+++ b/Sources/iOS/Editor.swift
@@ -251,7 +251,7 @@ private extension Editor {
   
   /// Prepares the detailLabel.
   func prepareDetailLabel() {
-    detailLabel.font = RobotoFont.regular(with: 12)
+    detailLabel.font = Theme.font.regular(with: 12)
     detailLabel.numberOfLines = 0
     detailColor = Color.darkText.others
     addSubview(detailLabel)

--- a/Sources/iOS/ErrorTextField.swift
+++ b/Sources/iOS/ErrorTextField.swift
@@ -83,7 +83,7 @@ open class ErrorTextField: TextField {
   
   /// Prepares the errorLabel.
   func prepareErrorLabel() {
-    errorLabel.font = RobotoFont.regular(with: 12)
+    errorLabel.font = Theme.font.regular(with: 12)
     errorLabel.numberOfLines = 0
     errorColor = { errorColor }() // call didSet
     addSubview(errorLabel)

--- a/Sources/iOS/FABMenu.swift
+++ b/Sources/iOS/FABMenu.swift
@@ -129,7 +129,7 @@ extension FABMenuItem {
   
   /// Prepares the titleLabel.
   fileprivate func prepareTitleLabel() {
-    titleLabel.font = RobotoFont.regular(with: 14)
+    titleLabel.font = Theme.font.regular(with: 14)
     titleLabel.textAlignment = .center
     titleLabel.backgroundColor = .white
     titleLabel.depthPreset = fabButton.depthPreset

--- a/Sources/iOS/Font.swift
+++ b/Sources/iOS/Font.swift
@@ -30,7 +30,28 @@
 
 import UIKit
 
-public protocol FontType {}
+public protocol FontType {
+  /**
+   Regular with size font.
+   - Parameter with size: A CGFLoat for the font size.
+   - Returns: A UIFont.
+   */
+  static func regular(with size: CGFloat) -> UIFont
+  
+  /**
+   Medium with size font.
+   - Parameter with size: A CGFLoat for the font size.
+   - Returns: A UIFont.
+   */
+  static func medium(with size: CGFloat) -> UIFont
+  
+  /**
+   Bold with size font.
+   - Parameter with size: A CGFLoat for the font size.
+   - Returns: A UIFont.
+   */
+  static func bold(with size: CGFloat) -> UIFont
+}
 
 public struct Font {
   /// Size of font.

--- a/Sources/iOS/SearchBar.swift
+++ b/Sources/iOS/SearchBar.swift
@@ -213,7 +213,7 @@ fileprivate extension SearchBar {
   /// Prepares the textField.
   func prepareTextField() {
     textField.contentScaleFactor = Screen.scale
-    textField.font = RobotoFont.regular(with: 17)
+    textField.font = Theme.font.regular(with: 17)
     textField.backgroundColor = Color.clear
     textField.clearButtonMode = .whileEditing
     textField.addTarget(self, action: #selector(handleEditingChanged(textField:)), for: .editingChanged)

--- a/Sources/iOS/Snackbar.swift
+++ b/Sources/iOS/Snackbar.swift
@@ -104,7 +104,7 @@ open class Snackbar: Bar {
   /// Prepares the textLabel.
   private func prepareTextLabel() {
     textLabel.contentScaleFactor = Screen.scale
-    textLabel.font = RobotoFont.medium(with: 14)
+    textLabel.font = Theme.font.medium(with: 14)
     textLabel.textAlignment = .left
     textLabel.textColor = .white
     textLabel.numberOfLines = 0

--- a/Sources/iOS/TextField.swift
+++ b/Sources/iOS/TextField.swift
@@ -450,7 +450,7 @@ open class TextField: UITextField, Themeable {
     borderStyle = .none
     backgroundColor = nil
     contentScaleFactor = Screen.scale
-    font = RobotoFont.regular(with: 16)
+    font = Theme.font.regular(with: 16)
     textColor = Color.darkText.primary
     
     prepareDivider()
@@ -496,7 +496,7 @@ fileprivate extension TextField {
   
   /// Prepares the detailLabel.
   func prepareDetailLabel() {
-    detailLabel.font = RobotoFont.regular(with: 12)
+    detailLabel.font = Theme.font.regular(with: 12)
     detailLabel.numberOfLines = 0
     detailColor = Color.darkText.others
     addSubview(detailLabel)

--- a/Sources/iOS/TextView.swift
+++ b/Sources/iOS/TextView.swift
@@ -283,7 +283,7 @@ open class TextView: UITextView, Themeable {
     contentScaleFactor = Screen.scale
     textContainerInset = .zero
     backgroundColor = nil
-    font = RobotoFont.regular(with: 16)
+    font = Theme.font.regular(with: 16)
     textColor = Color.darkText.primary
     
     prepareNotificationHandlers()

--- a/Sources/iOS/Theme.swift
+++ b/Sources/iOS/Theme.swift
@@ -77,6 +77,9 @@ public struct Theme: Hashable {
   /// A boolean indicating if theming is enabled globally.
   public static var isEnabled = true
   
+  /// Global font for app.
+  public static var font: FontType.Type = RobotoFont.self
+  
   /// An initializer.
   public init() { }
 }

--- a/Sources/iOS/Toolbar.swift
+++ b/Sources/iOS/Toolbar.swift
@@ -184,7 +184,7 @@ private extension Toolbar {
   func prepareTitleLabel() {
     titleLabel.textAlignment = .center
     titleLabel.contentScaleFactor = Screen.scale
-    titleLabel.font = RobotoFont.medium(with: 17)
+    titleLabel.font = Theme.font.medium(with: 17)
     titleLabel.textColor = Color.darkText.primary
     titleLabelTextAlignmentObserver = titleLabel.observe(\.textAlignment) { [weak self] titleLabel, _ in
       self?.contentViewAlignment = .center == titleLabel.textAlignment ? .center : .full
@@ -195,7 +195,7 @@ private extension Toolbar {
   func prepareDetailLabel() {
     detailLabel.textAlignment = .center
     detailLabel.contentScaleFactor = Screen.scale
-    detailLabel.font = RobotoFont.regular(with: 12)
+    detailLabel.font = Theme.font.regular(with: 12)
     detailLabel.textColor = Color.darkText.secondary
   }
   

--- a/Sources/iOS/ViewController.swift
+++ b/Sources/iOS/ViewController.swift
@@ -45,6 +45,7 @@ open class ViewController: UIViewController, Themeable {
    */
   open func prepare() {
     view.clipsToBounds = true
+    view.backgroundColor = .white
     view.contentScaleFactor = Screen.scale
     applyCurrentTheme()
   }


### PR DESCRIPTION
Global theme can be changed in `Theme.font`. The value has to be a type that conforms to `FontType`. For example, to use `Theme.font = UIFont.self`, it has to be conformed to `FontType`:

```swift
extension UIFont: FontType {
  public static func regular(with size: CGFloat) -> UIFont {
    return systemFont(ofSize: size, weight: .regular)
  }
  
  public static func bold(with size: CGFloat) -> UIFont {
    return systemFont(ofSize: size, weight: .bold)
  }
  
  public static func medium(with size: CGFloat) -> UIFont {
    return systemFont(ofSize: size, weight: .medium)
  }
}
```