### PR TITLE
Reworked layout system

### DIFF
--- a/Material.xcodeproj/project.pbxproj
+++ b/Material.xcodeproj/project.pbxproj
@@ -174,6 +174,9 @@
 		9D054A6520D175AC00D0528D /* Material+UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D054A6320D175AC00D0528D /* Material+UIButton.swift */; };
 		9D054A6620D175AC00D0528D /* Material+UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D054A6420D175AC00D0528D /* Material+UILabel.swift */; };
 		9D39A81B20FE8ED100BA8FA1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D39A81A20FE8ED100BA8FA1 /* ViewController.swift */; };
+		9D494A38217F6B63003D66F1 /* LayoutAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D494A37217F6B63003D66F1 /* LayoutAttribute.swift */; };
+		9D494A3A217F6B70003D66F1 /* LayoutAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D494A39217F6B70003D66F1 /* LayoutAnchor.swift */; };
+		9D494A3C217F6B7D003D66F1 /* LayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D494A3B217F6B7D003D66F1 /* LayoutConstraint.swift */; };
 		9D9089B92118914500605DC9 /* Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9089B82118914500605DC9 /* Editor.swift */; };
 		9DE25DE02170D7AF000C04DF /* Dialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE25DDF2170D7AF000C04DF /* Dialog.swift */; };
 		9DE25DE22170D7C0000C04DF /* DialogController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE25DE12170D7C0000C04DF /* DialogController.swift */; };
@@ -300,6 +303,9 @@
 		9D054A6320D175AC00D0528D /* Material+UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Material+UIButton.swift"; sourceTree = "<group>"; };
 		9D054A6420D175AC00D0528D /* Material+UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Material+UILabel.swift"; sourceTree = "<group>"; };
 		9D39A81A20FE8ED100BA8FA1 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		9D494A37217F6B63003D66F1 /* LayoutAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutAttribute.swift; sourceTree = "<group>"; };
+		9D494A39217F6B70003D66F1 /* LayoutAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutAnchor.swift; sourceTree = "<group>"; };
+		9D494A3B217F6B7D003D66F1 /* LayoutConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConstraint.swift; sourceTree = "<group>"; };
 		9D9089B82118914500605DC9 /* Editor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Editor.swift; sourceTree = "<group>"; };
 		9DE25DDF2170D7AF000C04DF /* Dialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dialog.swift; sourceTree = "<group>"; };
 		9DE25DE12170D7C0000C04DF /* DialogController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogController.swift; sourceTree = "<group>"; };
@@ -652,6 +658,9 @@
 			isa = PBXGroup;
 			children = (
 				96BCB7811CB40DC500C806FE /* Layout.swift */,
+				9D494A39217F6B70003D66F1 /* LayoutAnchor.swift */,
+				9D494A37217F6B63003D66F1 /* LayoutAttribute.swift */,
+				9D494A3B217F6B7D003D66F1 /* LayoutConstraint.swift */,
 			);
 			name = Layout;
 			sourceTree = "<group>";
@@ -993,6 +1002,7 @@
 				9DF352461FED210000B2A11B /* CheckButton.swift in Sources */,
 				965E810A1DD4D5C800D61E4B /* Font.swift in Sources */,
 				965E810B1DD4D5C800D61E4B /* RobotoFont.swift in Sources */,
+				9D494A3C217F6B7D003D66F1 /* LayoutConstraint.swift in Sources */,
 				965E810C1DD4D5C800D61E4B /* DynamicFontType.swift in Sources */,
 				965E81101DD4D5C800D61E4B /* NavigationBar.swift in Sources */,
 				965E81111DD4D5C800D61E4B /* NavigationController.swift in Sources */,
@@ -1015,6 +1025,7 @@
 				965E81211DD4D5C800D61E4B /* TextStorage.swift in Sources */,
 				965E81221DD4D5C800D61E4B /* TextView.swift in Sources */,
 				965E80E71DD4C55200D61E4B /* Material+UIView.swift in Sources */,
+				9D494A38217F6B63003D66F1 /* LayoutAttribute.swift in Sources */,
 				96B8D22D20CF82D5008BD149 /* FABMenu.swift in Sources */,
 				965E80E81DD4C55200D61E4B /* Material+CALayer.swift in Sources */,
 				965E80E91DD4C55200D61E4B /* Material+String.swift in Sources */,
@@ -1054,6 +1065,7 @@
 				965E80D21DD4C50600D61E4B /* Color.swift in Sources */,
 				96BFC1541E5E486F0075DE1F /* SpringAnimation.swift in Sources */,
 				9D054A6620D175AC00D0528D /* Material+UILabel.swift in Sources */,
+				9D494A3A217F6B70003D66F1 /* LayoutAnchor.swift in Sources */,
 				965E80D31DD4C50600D61E4B /* Device.swift in Sources */,
 				965E80FD1DD4D59500D61E4B /* Toolbar.swift in Sources */,
 				965E80D41DD4C50600D61E4B /* Divider.swift in Sources */,

--- a/Sources/iOS/ErrorTextField.swift
+++ b/Sources/iOS/ErrorTextField.swift
@@ -69,9 +69,10 @@ open class ErrorTextField: TextField {
     get {
       return !errorLabel.isHidden
     }
-    set {
-      errorLabel.isHidden = !newValue
-      detailLabel.isHidden = newValue
+    set(value) {
+      errorLabel.isHidden = !value
+      detailLabel.isHidden = value
+      layoutSubviews()
     }
   }
   

--- a/Sources/iOS/Layout.swift
+++ b/Sources/iOS/Layout.swift
@@ -32,11 +32,11 @@ import UIKit
 import Motion
 
 /// A protocol that's conformed by UIView and UILayoutGuide.
-public protocol Layoutable: class { }
+public protocol Constraintable: class { }
 
 @available(iOS 9.0, *)
-extension UILayoutGuide: Layoutable { }
-extension UIView: Layoutable { }
+extension UILayoutGuide: Constraintable { }
+extension UIView: Constraintable { }
 
 /// Layout extension for UIView.
 public extension UIView {
@@ -53,7 +53,7 @@ public extension UIView {
   
   /// Layout instance for the view.
   var layout: Layout {
-    return Layout(view: self)
+    return Layout(constraintable: self)
   }
   
   /**
@@ -62,7 +62,7 @@ public extension UIView {
    */
   var safeLayout: Layout {
     if #available(iOS 11.0, *) {
-      return Layout(view: safeAreaLayoutGuide)
+      return Layout(constraintable: safeAreaLayoutGuide)
     } else {
       return layout
     }
@@ -70,20 +70,20 @@ public extension UIView {
 }
 
 public struct Layout {
-  /// A weak reference to the view.
-  weak var view: Layoutable?
+  /// A weak reference to the constraintable.
+  weak var constraintable: Constraintable?
   
   /// Parent view of the view.
   var parent: UIView? {
-    return (view as? UIView)?.superview
+    return (constraintable as? UIView)?.superview
   }
   
   /**
-   An initializer taking UIView.
-   - Parameter view: A UIView.
+   An initializer taking Constraintable.
+   - Parameter view: A Constraintable.
    */
-  init(view: Layoutable) {
-    self.view = view
+  init(constraintable: Constraintable) {
+    self.constraintable = constraintable
   }
 }
 
@@ -494,9 +494,9 @@ private extension Layout {
     
     if attributes == .constantHeight || attributes == .constantWidth {
       attributes.removeLast()
-      anchor = LayoutAnchor(view: nil, attributes: [.notAnAttribute])
+      anchor = LayoutAnchor(constraintable: nil, attributes: [.notAnAttribute])
     } else {
-      anchor = LayoutAnchor(view: parent, attributes: attributes)
+      anchor = LayoutAnchor(constraintable: parent, attributes: attributes)
     }
     return constraint(attributes, to: anchor, constants: constants)
   }
@@ -534,13 +534,13 @@ private extension Layout {
    - Returns: A Layout instance to allow chaining.
    */
   func constraint(_ attributes: [LayoutAttribute], to anchor: LayoutAnchorable, constants: [CGFloat]) -> Layout {
-    let from = LayoutAnchor(view: view, attributes: attributes)
-    let to =  anchor as? LayoutAnchor ?? LayoutAnchor(view: (anchor as? UIView) ?? (anchor as? Layout)?.view, attributes: attributes)
+    let from = LayoutAnchor(constraintable: constraintable, attributes: attributes)
+    let to =  anchor as? LayoutAnchor ?? LayoutAnchor(constraintable: (anchor as? UIView) ?? (anchor as? Layout)?.constraintable, attributes: attributes)
     let constraint = LayoutConstraint(fromAnchor: from, toAnchor: to, constants: constants)
     
-    var  v = view as? UIView
+    var  v = constraintable as? UIView
     if #available(iOS 9.0, *), v == nil {
-       v = (view as? UILayoutGuide)?.owningView
+       v = (constraintable as? UILayoutGuide)?.owningView
     }
     
     let constraints = (v?.constraints ?? []) + (v?.superview?.constraints ?? [])

--- a/Sources/iOS/Layout.swift
+++ b/Sources/iOS/Layout.swift
@@ -56,15 +56,20 @@ public extension UIView {
     return Layout(constraintable: self)
   }
   
+  /// Anchor instance for the view.
+  var anchor: LayoutAnchor {
+    return LayoutAnchor(constraintable: self)
+  }
+  
   /**
-   Layout instance for safeAreaLayoutGuide.
-   Below iOS 11, it will be same as view.layout.
+   Anchor instance for safeAreaLayoutGuide.
+   Below iOS 11, it will be same as view.anchor.
    */
-  var safeLayout: Layout {
+  var safeAnchor: LayoutAnchor {
     if #available(iOS 11.0, *) {
-      return Layout(constraintable: safeAreaLayoutGuide)
+      return LayoutAnchor(constraintable: safeAreaLayoutGuide)
     } else {
-      return layout
+      return anchor
     }
   }
 }
@@ -535,8 +540,12 @@ private extension Layout {
    */
   func constraint(_ attributes: [LayoutAttribute], to anchor: LayoutAnchorable, constants: [CGFloat]) -> Layout {
     let from = LayoutAnchor(constraintable: constraintable, attributes: attributes)
-    let to =  anchor as? LayoutAnchor ?? LayoutAnchor(constraintable: (anchor as? UIView) ?? (anchor as? Layout)?.constraintable, attributes: attributes)
-    let constraint = LayoutConstraint(fromAnchor: from, toAnchor: to, constants: constants)
+    var to = anchor as? LayoutAnchor
+    if to?.attributes.isEmpty ?? true {
+      let v = (anchor as? UIView) ?? (anchor as? LayoutAnchor)?.constraintable
+      to = LayoutAnchor(constraintable: v, attributes: attributes)
+    }
+    let constraint = LayoutConstraint(fromAnchor: from, toAnchor: to!, constants: constants)
     
     var  v = constraintable as? UIView
     if #available(iOS 9.0, *), v == nil {

--- a/Sources/iOS/Layout.swift
+++ b/Sources/iOS/Layout.swift
@@ -265,179 +265,179 @@ public extension Layout {
 public extension Layout {
   /**
    Constraints top of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter _ offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func top(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+  func top(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
     return constraint(.top, to: anchor, constant: offset)
   }
   
   /**
    Constraints left of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter _ offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func left(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+  func left(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
     return constraint(.left, to: anchor, constant: offset)
   }
   
   /**
    Constraints right of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter _ offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func right(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+  func right(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
     return constraint(.right, to: anchor, constant: -offset)
   }
   
   /**
    Constraints bottom of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter _ offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func bottom(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+  func bottom(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
     return constraint(.bottom, to: anchor, constant: -offset)
   }
   
   /**
    Constraints top-left of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter top: A CGFloat offset for top.
    - Parameter left: A CGFloat offset for left.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func topLeft(_ anchor: LayoutAnchor, top: CGFloat = 0, left: CGFloat = 0) -> Layout {
+  func topLeft(_ anchor: LayoutAnchorable, top: CGFloat = 0, left: CGFloat = 0) -> Layout {
     return constraint(.topLeft, to: anchor, constants: top, left)
   }
   
   /**
    Constraints top-right of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter top: A CGFloat offset for top.
    - Parameter right: A CGFloat offset for right.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func topRight(_ anchor: LayoutAnchor, top: CGFloat = 0, right: CGFloat = 0) -> Layout {
+  func topRight(_ anchor: LayoutAnchorable, top: CGFloat = 0, right: CGFloat = 0) -> Layout {
     return constraint(.topRight, to: anchor, constants: top, -right)
   }
   
   /**
    Constraints bottom-left of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter bottom: A CGFloat offset for bottom.
    - Parameter left: A CGFloat offset for left.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func bottomLeft(_ anchor: LayoutAnchor, bottom: CGFloat = 0, left: CGFloat = 0) -> Layout {
+  func bottomLeft(_ anchor: LayoutAnchorable, bottom: CGFloat = 0, left: CGFloat = 0) -> Layout {
     return constraint(.bottomLeft, to: anchor, constants: -bottom, left)
   }
   
   /**
    Constraints bottom-right of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter bottom: A CGFloat offset for bottom.
    - Parameter right: A CGFloat offset for right.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func bottomRight(_ anchor: LayoutAnchor, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
+  func bottomRight(_ anchor: LayoutAnchorable, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
     return constraint(.bottomRight, to: anchor, constants: -bottom, -right)
   }
   
   /**
    Constraints left and right of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter left: A CGFloat offset for left.
    - Parameter right: A CGFloat offset for right.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func leftRight(_ anchor: LayoutAnchor, left: CGFloat = 0, right: CGFloat = 0) -> Layout {
+  func leftRight(_ anchor: LayoutAnchorable, left: CGFloat = 0, right: CGFloat = 0) -> Layout {
     return constraint(.leftRight, to: anchor, constants: left, -right)
   }
   
   /**
    Constraints top and bottom of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter top: A CGFloat offset for top.
    - Parameter bottom: A CGFloat offset for bottom.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func topBottom(_ anchor: LayoutAnchor, top: CGFloat = 0, bottom: CGFloat = 0) -> Layout {
+  func topBottom(_ anchor: LayoutAnchorable, top: CGFloat = 0, bottom: CGFloat = 0) -> Layout {
     return constraint(.topBottom, to: anchor, constants: top, -bottom)
   }
   
   /**
    Constraints center of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter offsetX: A CGFloat offset for horizontal center.
    - Parameter offsetY: A CGFloat offset for vertical center.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func center(_ anchor: LayoutAnchor, offsetX: CGFloat = 0, offsetY: CGFloat = 0) -> Layout {
+  func center(_ anchor: LayoutAnchorable, offsetX: CGFloat = 0, offsetY: CGFloat = 0) -> Layout {
     return constraint(.center, to: anchor, constants: offsetX, offsetY)
   }
   
   /**
    Constraints horizontal center of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter _ offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func centerX(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+  func centerX(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
     return constraint(.centerX, to: anchor, constant: offset)
   }
   
   /**
    Constraints vertical center of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter _ offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func centerY(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+  func centerY(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
     return constraint(.centerY, to: anchor, constant: offset)
   }
   
   /**
    Constraints height of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func width(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+  func width(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
     return constraint(.width, to: anchor, constant: offset)
   }
   
   /**
    Constraints height of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func height(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+  func height(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
     return constraint(.height, to: anchor, constant: offset)
   }
   
   /**
    Constraints edges of the view to the given anchor.
-   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ anchor: A LayoutAnchorable.
    - Parameter top: A CGFloat offset for top.
    - Parameter left: A CGFloat offset for left.
    - Parameter bottom: A CGFloat offset for bottom.
@@ -445,7 +445,7 @@ public extension Layout {
    - Returns: A Layout instance to allow chaining.
    */
   @discardableResult
-  func edges(_ anchor: LayoutAnchor, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
+  func edges(_ anchor: LayoutAnchorable, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
     return constraint(.edges, to: anchor, constants: top, left, -bottom, -right)
   }
 }
@@ -486,11 +486,11 @@ private extension Layout {
    Constraints the view to the given anchor according to the provided attribute.
    If the constraint already exists, will update its constant.
    - Parameter _ attribute: A LayoutAttribute.
-   - Parameter to anchor: A LayoutAnchor.
+   - Parameter to anchor: A LayoutAnchorable.
    - Parameter constant: A CGFloat.
    - Returns: A Layout instance to allow chaining.
    */
-  func constraint(_ attribute: LayoutAttribute, to anchor: LayoutAnchor, constant: CGFloat) -> Layout {
+  func constraint(_ attribute: LayoutAttribute, to anchor: LayoutAnchorable, constant: CGFloat) -> Layout {
     return constraint([attribute], to: anchor, constants: constant)
   }
   
@@ -498,11 +498,11 @@ private extension Layout {
    Constraints the view to the given anchor according to the provided attributes.
    If any of the constraints already exists, will update its constant.
    - Parameter _ attributes: An array of LayoutAttribute.
-   - Parameter to anchor: A LayoutAnchor.
+   - Parameter to anchor: A LayoutAnchorable.
    - Parameter constants: A list of CGFloat.
    - Returns: A Layout instance to allow chaining.
    */
-  func constraint(_ attributes: [LayoutAttribute], to anchor: LayoutAnchor, constants: CGFloat...) -> Layout {
+  func constraint(_ attributes: [LayoutAttribute], to anchor: LayoutAnchorable, constants: CGFloat...) -> Layout {
     return constraint(attributes, to: anchor, constants: constants)
   }
   
@@ -510,13 +510,14 @@ private extension Layout {
    Constraints the view to the given anchor according to the provided attributes.
    If any of the constraints already exists, will update its constant.
    - Parameter _ attributes: An array of LayoutAttribute.
-   - Parameter to anchor: A LayoutAnchor.
+   - Parameter to anchor: A LayoutAnchorable.
    - Parameter constants: An array of CGFloat.
    - Returns: A Layout instance to allow chaining.
    */
-  func constraint(_ attributes: [LayoutAttribute], to anchor: LayoutAnchor, constants: [CGFloat]) -> Layout {
+  func constraint(_ attributes: [LayoutAttribute], to anchor: LayoutAnchorable, constants: [CGFloat]) -> Layout {
     let from = LayoutAnchor(view: view, attributes: attributes)
-    let constraint = LayoutConstraint(fromAnchor: from, toAnchor: anchor, constants: constants)
+    let to =  anchor as? LayoutAnchor ?? LayoutAnchor(view: anchor as? UIView, attributes: attributes)
+    let constraint = LayoutConstraint(fromAnchor: from, toAnchor: to, constants: constants)
     
     let constraints = (view?.constraints ?? []) + (parent?.constraints ?? [])
     let newConstraints = constraint.constraints

--- a/Sources/iOS/Layout.swift
+++ b/Sources/iOS/Layout.swift
@@ -31,970 +31,518 @@
 import UIKit
 import Motion
 
-public class Layout {
-  /// Parent UIView context.
-  internal weak var parent: UIView?
-  
-  /// Child UIView context.
-  internal weak var child: UIView?
-  
-  /**
-   An initializer that takes in a parent context.
-   - Parameter parent: An optional parent UIView.
-   */
-  public init(parent: UIView?) {
-    self.parent = parent
-  }
-  
-  /**
-   An initializer that takes in a parent context and child context.
-   - Parameter parent: An optional parent UIView.
-   - Parameter child: An optional child UIView.
-   */
-  public init(parent: UIView?, child: UIView?) {
-    self.parent = parent
-    self.child = child
-  }
-  
-  /**
-   Prints a debug message when the parent context is not available.
-   - Parameter function: A String representation of the function that
-   caused the issue.
-   - Returns: The current Layout instance.
-   */
-  internal func debugParentNotAvailableMessage(function: String = #function) -> Layout {
-    debugPrint("[Material Layout Error: Parent view context is not available for \(function).")
-    return self
-  }
-  
-  /**
-   Prints a debug message when the child context is not available.
-   - Parameter function: A String representation of the function that
-   caused the issue.
-   - Returns: The current Layout instance.
-   */
-  internal func debugChildNotAvailableMessage(function: String = #function) -> Layout {
-    debugPrint("[Material Layout Error: Child view context is not available for \(function).")
-    return self
-  }
-  
-  /**
-   Sets the width of a view.
-   - Parameter child: A child UIView to layout.
-   - Parameter width: A CGFloat value.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func width(_ child: UIView, width: CGFloat) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.width(parent: v, child: child, width: width)
-    return self
-  }
-  
-  /**
-   Sets the width of a view assuming a child context view.
-   - Parameter width: A CGFloat value.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func width(_ width: CGFloat) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return self.width(v, width: width)
-  }
-  
-  /**
-   Sets the height of a view.
-   - Parameter child: A child UIView to layout.
-   - Parameter height: A CGFloat value.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func height(_ child: UIView, height: CGFloat) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.height(parent: v, child: child, height: height)
-    return self
-  }
-  
-  /**
-   Sets the height of a view assuming a child context view.
-   - Parameter height: A CGFloat value.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func height(_ height: CGFloat) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return self.height(v, height: height)
-  }
-  
-  /**
-   Sets the width and height of a view.
-   - Parameter child: A child UIView to layout.
-   - Parameter size: A CGSize value.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func size(_ child: UIView, size: CGSize) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.size(parent: v, child: child, size: size)
-    return self
-  }
-  
-  /**
-   Sets the width and height of a view assuming a child context view.
-   - Parameter size: A CGSize value.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func size(_ size: CGSize = CGSize.zero) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return self.size(v, size: size)
-  }
-  
-  /**
-   A collection of children views are horizontally stretched with optional left,
-   right padding and interim interimSpace.
-   - Parameter children: An Array UIView to layout.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Parameter interimSpace: A CGFloat value for interim interimSpace.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func horizontally(_ children: [UIView], left: CGFloat = 0, right: CGFloat = 0, interimSpace: InterimSpace = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    Layout.horizontally(parent: v, children: children, left: left, right: right, interimSpace: interimSpace)
-    return self
-  }
-  
-  /**
-   A collection of children views are vertically stretched with optional top,
-   bottom padding and interim interimSpace.
-   - Parameter children: An Array UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter interimSpace: A CGFloat value for interim interimSpace.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func vertically(_ children: [UIView], top: CGFloat = 0, bottom: CGFloat = 0, interimSpace: InterimSpace = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    Layout.vertically(parent: v, children: children, top: top, bottom: bottom, interimSpace: interimSpace)
-    return self
-  }
-  
-  /**
-   A child view is horizontally stretched with optional left and right padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func horizontally(_ child: UIView, left: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.horizontally(parent: v, child: child, left: left, right: right)
-    return self
-  }
-  
-  /**
-   A child view is horizontally stretched with optional left and right padding.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func horizontally(left: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return horizontally(v, left: left, right: right)
-  }
-  
-  /**
-   A child view is vertically stretched with optional left and right padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func vertically(_ child: UIView, top: CGFloat = 0, bottom: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.vertically(parent: v, child: child, top: top, bottom: bottom)
-    return self
-  }
-  
-  /**
-   A child view is vertically stretched with optional left and right padding.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func vertically(top: CGFloat = 0, bottom: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return vertically(v, top: top, bottom: bottom)
-  }
-  
-  /**
-   A child view is vertically and horizontally stretched with optional top, left, bottom and right padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func edges(_ child: UIView, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.edges(parent: v, child: child, top: top, left: left, bottom: bottom, right: right)
-    return self
-  }
-  
-  /**
-   A child view is vertically and horizontally stretched with optional top, left, bottom and right padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func edges(top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return edges(v, top: top, left: left, bottom: bottom, right: right)
-  }
-  
-  /**
-   A child view is aligned from the top with optional top padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func top(_ child: UIView, top: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.top(parent: v, child: child, top: top)
-    return self
-  }
-  
-  /**
-   A child view is aligned from the top with optional top padding.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func top(_ top: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return self.top(v, top: top)
-  }
-  
-  /**
-   A child view is aligned from the left with optional left padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func left(_ child: UIView, left: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.left(parent: v, child: child, left: left)
-    return self
-  }
-  
-  /**
-   A child view is aligned from the left with optional left padding.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func left(_ left: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return self.left(v, left: left)
-  }
-  
-  /**
-   A child view is aligned from the bottom with optional bottom padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func bottom(_ child: UIView, bottom: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.bottom(parent: v, child: child, bottom: bottom)
-    return self
-  }
-  
-  /**
-   A child view is aligned from the bottom with optional bottom padding.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func bottom(_ bottom: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return self.bottom(v, bottom: bottom)
-  }
-  
-  /**
-   A child view is aligned from the right with optional right padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func right(_ child: UIView, right: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.right(parent: v, child: child, right: right)
-    return self
-  }
-  
-  /**
-   A child view is aligned from the right with optional right padding.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func right(_ right: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return self.right(v, right: right)
-  }
-  
-  /**
-   A child view is aligned from the top left with optional top and left padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func topLeft(_ child: UIView, top: CGFloat = 0, left: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.topLeft(parent: v, child: child, top: top, left: left)
-    return self
-  }
-  
-  /**
-   A child view is aligned from the top left with optional top and left padding.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func topLeft(top: CGFloat = 0, left: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return topLeft(v, top: top, left: left)
-  }
-  
-  /**
-   A child view is aligned from the top right with optional top and right padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func topRight(_ child: UIView, top: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.topRight(parent: v, child: child, top: top, right: right)
-    return self
-  }
-  
-  /**
-   A child view is aligned from the top right with optional top and right padding.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func topRight(top: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return topRight(v, top: top, right: right)
-  }
-  
-  /**
-   A child view is aligned from the bottom left with optional bottom and left padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func bottomLeft(_ child: UIView, bottom: CGFloat = 0, left: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.bottomLeft(parent: v, child: child, bottom: bottom, left: left)
-    return self
-  }
-  
-  /**
-   A child view is aligned from the bottom left with optional bottom and left padding.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func bottomLeft(bottom: CGFloat = 0, left: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return bottomLeft(v, bottom: bottom, left: left)
-  }
-  
-  /**
-   A child view is aligned from the bottom right with optional bottom and right padding.
-   - Parameter child: A child UIView to layout.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func bottomRight(_ child: UIView, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.bottomRight(parent: v, child: child, bottom: bottom, right: right)
-    return self
-  }
-  
-  /**
-   A child view is aligned from the bottom right with optional bottom and right padding.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func bottomRight(bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return bottomRight(v, bottom: bottom, right: right)
-  }
-  
-  /**
-   A child view is aligned at the center with an optional offsetX and offsetY value.
-   - Parameter child: A child UIView to layout.
-   - Parameter offsetX: A CGFloat value for the offset along the x axis.
-   - Parameter offsetX: A CGFloat value for the offset along the y axis.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func center(_ child: UIView, offsetX: CGFloat = 0, offsetY: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.center(parent: v, child: child, offsetX: offsetX, offsetY: offsetY)
-    return self
-  }
-  
-  /**
-   A child view is aligned at the center with an optional offsetX and offsetY value.
-   - Parameter offsetX: A CGFloat value for the offset along the x axis.
-   - Parameter offsetX: A CGFloat value for the offset along the y axis.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func center(offsetX: CGFloat = 0, offsetY: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return center(v, offsetX: offsetX, offsetY: offsetY)
-  }
-  
-  /**
-   A child view is aligned at the center horizontally with an optional offset value.
-   - Parameter child: A child UIView to layout.
-   - Parameter offset: A CGFloat value for the offset along the x axis.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func centerHorizontally(_ child: UIView, offset: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.centerHorizontally(parent: v, child: child, offset: offset)
-    return self
-  }
-  
-  /**
-   A child view is aligned at the center horizontally with an optional offset value.
-   - Parameter offset: A CGFloat value for the offset along the x axis.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func centerHorizontally(offset: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return centerHorizontally(v, offset: offset)
-  }
-  
-  /**
-   A child view is aligned at the center vertically with an optional offset value.
-   - Parameter child: A child UIView to layout.
-   - Parameter offset: A CGFloat value for the offset along the y axis.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func centerVertically(_ child: UIView, offset: CGFloat = 0) -> Layout {
-    guard let v = parent else {
-      return debugParentNotAvailableMessage()
-    }
-    self.child = child
-    Layout.centerVertically(parent: v, child: child, offset: offset)
-    return self
-  }
-  
-  /**
-   A child view is aligned at the center vertically with an optional offset value.
-   - Parameter offset: A CGFloat value for the offset along the y axis.
-   - Returns: The current Layout instance.
-   */
-  @discardableResult
-  public func centerVertically(offset: CGFloat = 0) -> Layout {
-    guard let v = child else {
-      return debugChildNotAvailableMessage()
-    }
-    return centerVertically(v, offset: offset)
-  }
-}
-
-fileprivate extension Layout {
-  /**
-   Updates the consraints for a given view.
-   - Parameter for view: A UIView.
-   */
-  class func updateConstraints(for view: UIView) {
-    view.setNeedsUpdateConstraints()
-    view.updateConstraintsIfNeeded()
-    view.setNeedsLayout()
-    view.layoutIfNeeded()
-  }
-  
-  /**
-   Updates the constraints for a given Array of views.
-   - Parameter for [view]: An Array of UIViews.
-   */
-  class func updateConstraints(for views: [UIView]) {
-    for v in views {
-      updateConstraints(for: v)
-    }
-  }
-}
-
-/// Layout
-extension Layout {
-  /**
-   Sets the width of a view.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter width: A CGFloat value.
-   */
-  public class func width(parent: UIView, child: UIView, width: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .width, multiplier: 1, constant: width))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   Sets the height of a view.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter height: A CGFloat value.
-   */
-  public class func height(parent: UIView, child: UIView, height: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 1, constant: height))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   Sets the width and height of a view.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter size: A CGSize value.
-   */
-  public class func size(parent: UIView, child: UIView, size: CGSize = CGSize.zero) {
-    Layout.width(parent: parent, child: child, width: size.width)
-    Layout.height(parent: parent, child: child, height: size.height)
-  }
-  
-  /**
-   A collection of children views are horizontally stretched with optional left,
-   right padding and interim interimSpace.
-   - Parameter parent: A parent UIView context.
-   - Parameter children: An Array UIView to layout.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Parameter interimSpace: A CGFloat value for interim interimSpace.
-   */
-  public class func horizontally(parent: UIView, children: [UIView], left: CGFloat = 0, right: CGFloat = 0, interimSpace: InterimSpace = 0) {
-    prepareForConstraint(parent, children: children)
-    
-    if 0 < children.count {
-      parent.addConstraint(NSLayoutConstraint(item: children[0], attribute: .left, relatedBy: .equal, toItem: parent, attribute: .left, multiplier: 1, constant: left))
-      for i in 1..<children.count {
-        parent.addConstraint(NSLayoutConstraint(item: children[i], attribute: .left, relatedBy: .equal, toItem: children[i - 1], attribute: .right, multiplier: 1, constant: interimSpace))
-        parent.addConstraint(NSLayoutConstraint(item: children[i], attribute: .width, relatedBy: .equal, toItem: children[0], attribute: .width, multiplier: 1, constant: 0))
-      }
-      parent.addConstraint(NSLayoutConstraint(item: children[children.count - 1], attribute: .right, relatedBy: .equal, toItem: parent, attribute: .right, multiplier: 1, constant: -right))
-    }
-    
-    updateConstraints(for: children)
-  }
-  
-  /**
-   A collection of children views are vertically stretched with optional top,
-   bottom padding and interim interimSpace.
-   - Parameter parent: A parent UIView context.
-   - Parameter children: An Array UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter interimSpace: A CGFloat value for interim interimSpace.
-   */
-  public class func vertically(parent: UIView, children: [UIView], top: CGFloat = 0, bottom: CGFloat = 0, interimSpace: InterimSpace = 0) {
-    prepareForConstraint(parent, children: children)
-    
-    if 0 < children.count {
-      parent.addConstraint(NSLayoutConstraint(item: children[0], attribute: .top, relatedBy: .equal, toItem: parent, attribute: .top, multiplier: 1, constant: top))
-      for i in 1..<children.count {
-        parent.addConstraint(NSLayoutConstraint(item: children[i], attribute: .top, relatedBy: .equal, toItem: children[i - 1], attribute: .bottom, multiplier: 1, constant: interimSpace))
-        parent.addConstraint(NSLayoutConstraint(item: children[i], attribute: .height, relatedBy: .equal, toItem: children[0], attribute: .height, multiplier: 1, constant: 0))
-      }
-      parent.addConstraint(NSLayoutConstraint(item: children[children.count - 1], attribute: .bottom, relatedBy: .equal, toItem: parent, attribute: .bottom, multiplier: 1, constant: -bottom))
-    }
-    
-    updateConstraints(for: children)
-  }
-  
-  /**
-   A child view is horizontally stretched with optional left and right padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Parameter right: A CGFloat value for padding the right side.
-   */
-  public class func horizontally(parent: UIView, child: UIView, left: CGFloat = 0, right: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .left, relatedBy: .equal, toItem: parent, attribute: .left, multiplier: 1, constant: left))
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .right, relatedBy: .equal, toItem: parent, attribute: .right, multiplier: 1, constant: -right))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   A child view is vertically stretched with optional left and right padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   */
-  public class func vertically(parent: UIView, child: UIView, top: CGFloat = 0, bottom: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .top, relatedBy: .equal, toItem: parent, attribute: .top, multiplier: 1, constant: top))
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .bottom, relatedBy: .equal, toItem: parent, attribute: .bottom, multiplier: 1, constant: -bottom))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   A child view is vertically and horizontally stretched with optional top, left, bottom and right padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter right: A CGFloat value for padding the right side.
-   */
-  public class func edges(parent: UIView, child: UIView, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) {
-    horizontally(parent: parent, child: child, left: left, right: right)
-    vertically(parent: parent, child: child, top: top, bottom: bottom)
-  }
-  
-  /**
-   A child view is aligned from the top with optional top padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Returns: The current Layout instance.
-   */
-  public class func top(parent: UIView, child: UIView, top: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .top, relatedBy: .equal, toItem: parent, attribute: .top, multiplier: 1, constant: top))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   A child view is aligned from the left with optional left padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Returns: The current Layout instance.
-   */
-  public class func left(parent: UIView, child: UIView, left: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .left, relatedBy: .equal, toItem: parent, attribute: .left, multiplier: 1, constant: left))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   A child view is aligned from the bottom with optional bottom padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Returns: The current Layout instance.
-   */
-  public class func bottom(parent: UIView, child: UIView, bottom: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .bottom, relatedBy: .equal, toItem: parent, attribute: .bottom, multiplier: 1, constant: -bottom))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   A child view is aligned from the right with optional right padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  public class func right(parent: UIView, child: UIView, right: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .right, relatedBy: .equal, toItem: parent, attribute: .right, multiplier: 1, constant: -right))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   A child view is aligned from the top left with optional top and left padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Returns: The current Layout instance.
-   */
-  public class func topLeft(parent: UIView, child: UIView, top t: CGFloat = 0, left l: CGFloat = 0) {
-    top(parent: parent, child: child, top: t)
-    left(parent: parent, child: child, left: l)
-  }
-  
-  /**
-   A child view is aligned from the top right with optional top and right padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter top: A CGFloat value for padding the top side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  public class func topRight(parent: UIView, child: UIView, top t: CGFloat = 0, right r: CGFloat = 0) {
-    top(parent: parent, child: child, top: t)
-    right(parent: parent, child: child, right: r)
-  }
-  
-  /**
-   A child view is aligned from the bottom left with optional bottom and left padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter left: A CGFloat value for padding the left side.
-   - Returns: The current Layout instance.
-   */
-  public class func bottomLeft(parent: UIView, child: UIView, bottom b: CGFloat = 0, left l: CGFloat = 0) {
-    bottom(parent: parent, child: child, bottom: b)
-    left(parent: parent, child: child, left: l)
-  }
-  
-  /**
-   A child view is aligned from the bottom right with optional bottom and right padding.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter bottom: A CGFloat value for padding the bottom side.
-   - Parameter right: A CGFloat value for padding the right side.
-   - Returns: The current Layout instance.
-   */
-  public class func bottomRight(parent: UIView, child: UIView, bottom b: CGFloat = 0, right r: CGFloat = 0) {
-    bottom(parent: parent, child: child, bottom: b)
-    right(parent: parent, child: child, right: r)
-  }
-  
-  /**
-   A child view is aligned at the center with an optional offsetX and offsetY value.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter offsetX: A CGFloat value for the offset along the x axis.
-   - Parameter offsetX: A CGFloat value for the offset along the y axis.
-   - Returns: The current Layout instance.
-   */
-  public class func center(parent: UIView, child: UIView, offsetX: CGFloat = 0, offsetY: CGFloat = 0) {
-    centerHorizontally(parent: parent, child: child, offset: offsetX)
-    centerVertically(parent: parent, child: child, offset: offsetY)
-  }
-  
-  /**
-   A child view is aligned at the center horizontally with an optional offset value.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter offset: A CGFloat value for the offset along the y axis.
-   - Returns: The current Layout instance.
-   */
-  public class func centerHorizontally(parent: UIView, child: UIView, offset: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .centerX, relatedBy: .equal, toItem: parent, attribute: .centerX, multiplier: 1, constant: offset))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   A child view is aligned at the center vertically with an optional offset value.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   - Parameter offset: A CGFloat value for the offset along the y axis.
-   - Returns: The current Layout instance.
-   */
-  public class func centerVertically(parent: UIView, child: UIView, offset: CGFloat = 0) {
-    prepareForConstraint(parent, child: child)
-    parent.addConstraint(NSLayoutConstraint(item: child, attribute: .centerY, relatedBy: .equal, toItem: parent, attribute: .centerY, multiplier: 1, constant: offset))
-    updateConstraints(for: child)
-  }
-  
-  /**
-   Creats an Array with a NSLayoutConstraint value.
-   - Parameter format: The VFL format string.
-   - Parameter options: Additional NSLayoutFormatOptions.
-   - Parameter metrics: An optional Dictionary<String, Any> of metric key / value pairs.
-   - Parameter views: A Dictionary<String, Any> of view key / value pairs.
-   - Returns: The Array<NSLayoutConstraint> instance.
-   */
-  public class func constraint(format: String, options: NSLayoutConstraint.FormatOptions, metrics: [String: Any]?, views: [String: Any]) -> [NSLayoutConstraint] {
-    for (_, a) in views {
-      if let v = a as? UIView {
-        v.translatesAutoresizingMaskIntoConstraints = false
-      }
-    }
-    return NSLayoutConstraint.constraints(
-      withVisualFormat: format,
-      options: options,
-      metrics: metrics,
-      views: views
-    )
-  }
-  
-  /**
-   Prepares the relationship between the parent view context and child view
-   to layout. If the child is not already added to the view hierarchy as the
-   parent's child, then it is added.
-   - Parameter parent: A parent UIView context.
-   - Parameter child: A child UIView to layout.
-   */
-  private class func prepareForConstraint(_ parent: UIView, child: UIView) {
-    if parent != child.superview {
-      child.removeFromSuperview()
-      parent.addSubview(child)
-    }
-    child.translatesAutoresizingMaskIntoConstraints = false
-  }
-  
-  /**
-   Prepares the relationship between the parent view context and an Array of
-   child UIViews.
-   - Parameter parent: A parent UIView context.
-   - Parameter children: An Array of UIViews.
-   */
-  private class func prepareForConstraint(_ parent: UIView, children: [UIView]) {
-    for v in children {
-      prepareForConstraint(parent, child: v)
-    }
-  }
-}
-
-/// A memory reference to the LayoutKey instance for UIView extensions.
-fileprivate var LayoutKey: UInt8 = 0
-
 /// Layout extension for UIView.
-extension UIView {
-  /// Layout reference.
-  public private(set) var layout: Layout {
-    get {
-      return AssociatedObject.get(base: self, key: &LayoutKey) {
-        return Layout(parent: self)
-      }
-    }
-    set(value) {
-      AssociatedObject.set(base: self, key: &LayoutKey, value: value)
-    }
-  }
-  
+public extension UIView {
   /**
    Used to chain layout constraints on a child context.
    - Parameter child: A child UIView to layout.
-   - Returns: The current Layout instance.
+   - Returns: A Layout instance.
    */
-  public func layout(_ child: UIView) -> Layout {
-    return Layout(parent: self, child: child)
+  func layout(_ child: UIView) -> Layout {
+    addSubview(child)
+    child.translatesAutoresizingMaskIntoConstraints = false
+    return child.layout
+  }
+  
+  /// Layout instance for the view.
+  var layout: Layout {
+    return Layout(view: self)
+  }
+}
+
+public struct Layout {
+  /// A weak reference to the view.
+  weak var view: UIView?
+  
+  /// Parent view of the view.
+  var parent: UIView? {
+    return view?.superview
+  }
+  
+  /**
+   An initializer taking UIView.
+   - Parameter view: A UIView.
+   */
+  init(view: UIView) {
+    self.view = view
+  }
+}
+
+public extension Layout {
+  /**
+   Constraints top of the view to its parent's.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func top(_ offset: CGFloat = 0) -> Layout {
+    return constraint(.top, constant: offset)
+  }
+  
+  /**
+   Constraints left of the view to its parent's.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func left(_ offset: CGFloat = 0) -> Layout {
+    return constraint(.left, constant: offset)
+  }
+  
+  /**
+   Constraints right of the view to its parent.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func right(_ offset: CGFloat = 0) -> Layout {
+    return constraint(.right, constant: offset)
+  }
+  
+  /**
+   Constraints bottom of the view to its parent's.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottom(_ offset: CGFloat = 0) -> Layout {
+    return constraint(.bottom, constant: offset)
+  }
+  
+  /**
+   Constraints top-left of the view to its parent's.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter left: A CGFloat offset for left.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topLeft(top: CGFloat = 0, left: CGFloat = 0) -> Layout {
+    return constraint(.topLeft, constants: top, left)
+  }
+  
+  /**
+   Constraints top-right of the view to its parent's.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter right: A CGFloat offset for right.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topRight(top: CGFloat = 0, right: CGFloat = 0) -> Layout {
+    return constraint(.topRight, constants: top, right)
+  }
+  
+  /**
+   Constraints bottom-left of the view to its parent's.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter left: A CGFloat offset for left.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottomLeft(bottom: CGFloat = 0, left: CGFloat = 0) -> Layout {
+    return constraint(.bottomLeft, constants: bottom, left)
+  }
+  
+  /**
+   Constraints bottom-right of the view to its parent's.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter right: A CGFloat offset for right.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottomRight(bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
+    return constraint(.bottomRight, constants: bottom, right)
+  }
+  
+  /**
+   Constraints left and right of the view to its parent's.
+   - Parameter left: A CGFloat offset for left.
+   - Parameter right: A CGFloat offset for right.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func leftRight(left: CGFloat = 0, right: CGFloat = 0) -> Layout {
+    return constraint(.leftRight, constants: left, right)
+  }
+  
+  /**
+   Constraints top and bottom of the view to its parent's.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topBottom(top: CGFloat = 0, bottom: CGFloat = 0) -> Layout {
+    return constraint(.topBottom, constants: top, bottom)
+  }
+  
+  /**
+   Constraints center of the view to its parent's.
+   - Parameter offsetX: A CGFloat offset for horizontal center.
+   - Parameter offsetY: A CGFloat offset for vertical center.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func center(offsetX: CGFloat = 0, offsetY: CGFloat = 0) -> Layout {
+    return constraint(.center, constants: offsetX, offsetY)
+  }
+  
+  /**
+   Constraints horizontal center of the view to its parent's.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func centerX(_ offset: CGFloat = 0) -> Layout {
+    return constraint(.centerX, constant: offset)
+  }
+  
+  /**
+   Constraints vertical center of the view to its parent's.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func centerY(_ offset: CGFloat = 0) -> Layout {
+    return constraint(.centerY, constant: offset)
+  }
+  
+  /**
+   Constraints width of the view to its parent's.
+   - Parameter offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func width(offset: CGFloat = 0) -> Layout {
+    return constraint(.width, constant: offset)
+  }
+  
+  /**
+   Constraints height of the view to its parent's.
+   - Parameter offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func height(offset: CGFloat = 0) -> Layout {
+    return constraint(.height, constant: offset)
+  }
+  
+  /**
+   Constraints edges of the view to its parent's.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter left: A CGFloat offset for left.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter right: A CGFloat offset for right.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func edges(top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
+    return constraint(.edges, constants: top, left, bottom, right)
+  }
+}
+
+public extension Layout {
+  /**
+   Constraints width of the view to a constant value.
+   - Parameter _ width: A CGFloat value.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func width(_ width: CGFloat) -> Layout {
+    return constraint(.constantWidth, constants: width)
+  }
+  
+  /**
+   Constraints height of the view to a constant value.
+   - Parameter _ height: A CGFloat value.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func height(_ height: CGFloat) -> Layout {
+    return constraint(.constantHeight, constants: height)
+  }
+}
+
+public extension Layout {
+  /**
+   Constraints top of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func top(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.top, to: anchor, constant: offset)
+  }
+  
+  /**
+   Constraints left of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func left(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.left, to: anchor, constant: offset)
+  }
+  
+  /**
+   Constraints right of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func right(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.right, to: anchor, constant: offset)
+  }
+  
+  /**
+   Constraints bottom of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottom(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.bottom, to: anchor, constant: offset)
+  }
+  
+  /**
+   Constraints top-left of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter left: A CGFloat offset for left.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topLeft(_ anchor: LayoutAnchor, top: CGFloat = 0, left: CGFloat = 0) -> Layout {
+    return constraint(.topLeft, to: anchor, constants: top, left)
+  }
+  
+  /**
+   Constraints top-right of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter right: A CGFloat offset for right.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topRight(_ anchor: LayoutAnchor, top: CGFloat = 0, right: CGFloat = 0) -> Layout {
+    return constraint(.topRight, to: anchor, constants: top, right)
+  }
+  
+  /**
+   Constraints bottom-left of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter left: A CGFloat offset for left.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottomLeft(_ anchor: LayoutAnchor, bottom: CGFloat = 0, left: CGFloat = 0) -> Layout {
+    return constraint(.bottomLeft, to: anchor, constants: bottom, left)
+  }
+  
+  /**
+   Constraints bottom-right of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter right: A CGFloat offset for right.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottomRight(_ anchor: LayoutAnchor, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
+    return constraint(.bottomRight, to: anchor, constants: bottom, right)
+  }
+  
+  /**
+   Constraints left and right of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter left: A CGFloat offset for left.
+   - Parameter right: A CGFloat offset for right.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func leftRight(_ anchor: LayoutAnchor, left: CGFloat = 0, right: CGFloat = 0) -> Layout {
+    return constraint(.leftRight, to: anchor, constants: left, right)
+  }
+  
+  /**
+   Constraints top and bottom of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topBottom(_ anchor: LayoutAnchor, top: CGFloat = 0, bottom: CGFloat = 0) -> Layout {
+    return constraint(.topBottom, to: anchor, constants: top, bottom)
+  }
+  
+  /**
+   Constraints center of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter offsetX: A CGFloat offset for horizontal center.
+   - Parameter offsetY: A CGFloat offset for vertical center.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func center(_ anchor: LayoutAnchor, offsetX: CGFloat = 0, offsetY: CGFloat = 0) -> Layout {
+    return constraint(.center, to: anchor, constants: offsetX, offsetY)
+  }
+  
+  /**
+   Constraints horizontal center of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func centerX(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.centerX, to: anchor, constant: offset)
+  }
+  
+  /**
+   Constraints vertical center of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func centerY(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.centerY, to: anchor, constant: offset)
+  }
+  
+  /**
+   Constraints height of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func width(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.width, to: anchor, constant: offset)
+  }
+  
+  /**
+   Constraints height of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func height(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.height, to: anchor, constant: offset)
+  }
+  
+  /**
+   Constraints edges of the view to the given anchor.
+   - Parameter _ acnhor: A LayoutAnchor.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter left: A CGFloat offset for left.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter right: A CGFloat offset for right.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func edges(_ anchor: LayoutAnchor, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
+    return constraint(.edges, to: anchor, constants: top, left, bottom, right)
+  }
+}
+
+private extension Layout {
+  /**
+   Constraints the view to its parent according to the provided attribute.
+   If the constraint already exists, will update its constant.
+   - Parameter _ attribute: A LayoutAttribute.
+   - Parameter constant: A CGFloat.
+   - Returns: A Layout instance to allow chaining.
+   */
+  func constraint(_ attribute: LayoutAttribute, constant: CGFloat) -> Layout {
+    return constraint([attribute], constants: constant)
+  }
+  
+  /**
+   Constraints the view to its parent according to the provided attributes.
+   If any of the constraints already exists, will update its constant.
+   - Parameter _ attributes: An array of LayoutAttribute.
+   - Parameter constants: A list of CGFloat.
+   - Returns: A Layout instance to allow chaining.
+   */
+  func constraint(_ attributes: [LayoutAttribute], constants: CGFloat...) -> Layout {
+    var attributes = attributes
+    var anchor: LayoutAnchor!
+    
+    if attributes == .constantHeight || attributes == .constantWidth {
+      attributes.removeLast()
+      anchor = LayoutAnchor(view: nil, attributes: [.notAnAttribute])
+    } else {
+      anchor = LayoutAnchor(view: parent, attributes: attributes)
+    }
+    return constraint(attributes, to: anchor, constants: constants)
+  }
+  
+  /**
+   Constraints the view to the given anchor according to the provided attribute.
+   If the constraint already exists, will update its constant.
+   - Parameter _ attribute: A LayoutAttribute.
+   - Parameter to anchor: A LayoutAnchor.
+   - Parameter constant: A CGFloat.
+   - Returns: A Layout instance to allow chaining.
+   */
+  func constraint(_ attribute: LayoutAttribute, to anchor: LayoutAnchor, constant: CGFloat) -> Layout {
+    return constraint([attribute], to: anchor, constants: constant)
+  }
+  
+  /**
+   Constraints the view to the given anchor according to the provided attributes.
+   If any of the constraints already exists, will update its constant.
+   - Parameter _ attributes: An array of LayoutAttribute.
+   - Parameter to anchor: A LayoutAnchor.
+   - Parameter constants: A list of CGFloat.
+   - Returns: A Layout instance to allow chaining.
+   */
+  func constraint(_ attributes: [LayoutAttribute], to anchor: LayoutAnchor, constants: CGFloat...) -> Layout {
+    return constraint(attributes, to: anchor, constants: constants)
+  }
+  
+  /**
+   Constraints the view to the given anchor according to the provided attributes.
+   If any of the constraints already exists, will update its constant.
+   - Parameter _ attributes: An array of LayoutAttribute.
+   - Parameter to anchor: A LayoutAnchor.
+   - Parameter constants: An array of CGFloat.
+   - Returns: A Layout instance to allow chaining.
+   */
+  func constraint(_ attributes: [LayoutAttribute], to anchor: LayoutAnchor, constants: [CGFloat]) -> Layout {
+    let from = LayoutAnchor(view: view, attributes: attributes)
+    let constraint = LayoutConstraint(fromAnchor: from, toAnchor: anchor, constants: constants)
+    
+    let constraints = (view?.constraints ?? []) + (parent?.constraints ?? [])
+    let newConstraints = constraint.constraints
+    for newConstraint in newConstraints {
+      guard let activeConstraint = constraints.first(where: { $0.equalTo(newConstraint) }) else {
+        newConstraint.isActive = true
+        continue
+      }
+      
+      activeConstraint.constant = newConstraint.constant
+    }
+    
+    return self
+  }
+}
+
+private extension NSLayoutConstraint {
+  /**
+   Checks if the constraint is equal to given constraint.
+   - Parameter _ other: An NSLayoutConstraint.
+   - Returns: A Bool indicating whether constraints are equal.
+   */
+  func equalTo(_ other: NSLayoutConstraint) -> Bool {
+    return firstItem === other.firstItem
+      && secondItem === other.secondItem
+      && firstAttribute == other.firstAttribute
+      && secondAttribute == other.secondAttribute
   }
 }

--- a/Sources/iOS/Layout.swift
+++ b/Sources/iOS/Layout.swift
@@ -658,6 +658,11 @@ private extension Layout {
       attributes.removeLast()
       anchor = LayoutAnchor(constraintable: nil, attributes: [.notAnAttribute])
     } else {
+      
+      guard parent != nil else {
+        fatalError("[Material Error: Constraint requires view to have parent.")
+      }
+      
       anchor = LayoutAnchor(constraintable: parent, attributes: attributes)
     }
     return constraint(attributes, to: anchor, constants: constants)

--- a/Sources/iOS/Layout.swift
+++ b/Sources/iOS/Layout.swift
@@ -96,7 +96,7 @@ public extension Layout {
    */
   @discardableResult
   func right(_ offset: CGFloat = 0) -> Layout {
-    return constraint(.right, constant: offset)
+    return constraint(.right, constant: -offset)
   }
   
   /**
@@ -106,7 +106,7 @@ public extension Layout {
    */
   @discardableResult
   func bottom(_ offset: CGFloat = 0) -> Layout {
-    return constraint(.bottom, constant: offset)
+    return constraint(.bottom, constant: -offset)
   }
   
   /**
@@ -128,7 +128,7 @@ public extension Layout {
    */
   @discardableResult
   func topRight(top: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    return constraint(.topRight, constants: top, right)
+    return constraint(.topRight, constants: top, -right)
   }
   
   /**
@@ -139,7 +139,7 @@ public extension Layout {
    */
   @discardableResult
   func bottomLeft(bottom: CGFloat = 0, left: CGFloat = 0) -> Layout {
-    return constraint(.bottomLeft, constants: bottom, left)
+    return constraint(.bottomLeft, constants: -bottom, left)
   }
   
   /**
@@ -150,7 +150,7 @@ public extension Layout {
    */
   @discardableResult
   func bottomRight(bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    return constraint(.bottomRight, constants: bottom, right)
+    return constraint(.bottomRight, constants: -bottom, -right)
   }
   
   /**
@@ -161,7 +161,7 @@ public extension Layout {
    */
   @discardableResult
   func leftRight(left: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    return constraint(.leftRight, constants: left, right)
+    return constraint(.leftRight, constants: left, -right)
   }
   
   /**
@@ -172,7 +172,7 @@ public extension Layout {
    */
   @discardableResult
   func topBottom(top: CGFloat = 0, bottom: CGFloat = 0) -> Layout {
-    return constraint(.topBottom, constants: top, bottom)
+    return constraint(.topBottom, constants: top, -bottom)
   }
   
   /**
@@ -236,7 +236,7 @@ public extension Layout {
    */
   @discardableResult
   func edges(top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    return constraint(.edges, constants: top, left, bottom, right)
+    return constraint(.edges, constants: top, left, -bottom, -right)
   }
 }
 
@@ -293,7 +293,7 @@ public extension Layout {
    */
   @discardableResult
   func right(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
-    return constraint(.right, to: anchor, constant: offset)
+    return constraint(.right, to: anchor, constant: -offset)
   }
   
   /**
@@ -304,7 +304,7 @@ public extension Layout {
    */
   @discardableResult
   func bottom(_ anchor: LayoutAnchor, _ offset: CGFloat = 0) -> Layout {
-    return constraint(.bottom, to: anchor, constant: offset)
+    return constraint(.bottom, to: anchor, constant: -offset)
   }
   
   /**
@@ -328,7 +328,7 @@ public extension Layout {
    */
   @discardableResult
   func topRight(_ anchor: LayoutAnchor, top: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    return constraint(.topRight, to: anchor, constants: top, right)
+    return constraint(.topRight, to: anchor, constants: top, -right)
   }
   
   /**
@@ -340,7 +340,7 @@ public extension Layout {
    */
   @discardableResult
   func bottomLeft(_ anchor: LayoutAnchor, bottom: CGFloat = 0, left: CGFloat = 0) -> Layout {
-    return constraint(.bottomLeft, to: anchor, constants: bottom, left)
+    return constraint(.bottomLeft, to: anchor, constants: -bottom, left)
   }
   
   /**
@@ -352,7 +352,7 @@ public extension Layout {
    */
   @discardableResult
   func bottomRight(_ anchor: LayoutAnchor, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    return constraint(.bottomRight, to: anchor, constants: bottom, right)
+    return constraint(.bottomRight, to: anchor, constants: -bottom, -right)
   }
   
   /**
@@ -364,7 +364,7 @@ public extension Layout {
    */
   @discardableResult
   func leftRight(_ anchor: LayoutAnchor, left: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    return constraint(.leftRight, to: anchor, constants: left, right)
+    return constraint(.leftRight, to: anchor, constants: left, -right)
   }
   
   /**
@@ -376,7 +376,7 @@ public extension Layout {
    */
   @discardableResult
   func topBottom(_ anchor: LayoutAnchor, top: CGFloat = 0, bottom: CGFloat = 0) -> Layout {
-    return constraint(.topBottom, to: anchor, constants: top, bottom)
+    return constraint(.topBottom, to: anchor, constants: top, -bottom)
   }
   
   /**
@@ -446,7 +446,7 @@ public extension Layout {
    */
   @discardableResult
   func edges(_ anchor: LayoutAnchor, top: CGFloat = 0, left: CGFloat = 0, bottom: CGFloat = 0, right: CGFloat = 0) -> Layout {
-    return constraint(.edges, to: anchor, constants: top, left, bottom, right)
+    return constraint(.edges, to: anchor, constants: top, left, -bottom, -right)
   }
 }
 

--- a/Sources/iOS/Layout.swift
+++ b/Sources/iOS/Layout.swift
@@ -124,6 +124,26 @@ public extension Layout {
   }
   
   /**
+   Constraints leading of the view to its parent's.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func leading(_ offset: CGFloat = 0) -> Layout {
+    return constraint(.leading, constant: offset)
+  }
+  
+  /**
+   Constraints trailing of the view to its parent.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func trailing(_ offset: CGFloat = 0) -> Layout {
+    return constraint(.trailing, constant: -offset)
+  }
+  
+  /**
    Constraints bottom of the view to its parent's.
    - Parameter _ offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.
@@ -186,6 +206,61 @@ public extension Layout {
   @discardableResult
   func leftRight(left: CGFloat = 0, right: CGFloat = 0) -> Layout {
     return constraint(.leftRight, constants: left, -right)
+  }
+  
+  /**
+   Constraints top-leading of the view to its parent's.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter leading: A CGFloat offset for leading.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topLeading(top: CGFloat = 0, leading: CGFloat = 0) -> Layout {
+    return constraint(.topLeading, constants: top, leading)
+  }
+  
+  /**
+   Constraints top-trailing of the view to its parent's.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter trailing: A CGFloat offset for trailing.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topTrailing(top: CGFloat = 0, trailing: CGFloat = 0) -> Layout {
+    return constraint(.topTrailing, constants: top, -trailing)
+  }
+  
+  /**
+   Constraints bottom-leading of the view to its parent's.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter leading: A CGFloat offset for leading.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottomLeading(bottom: CGFloat = 0, leading: CGFloat = 0) -> Layout {
+    return constraint(.bottomLeading, constants: -bottom, leading)
+  }
+  
+  /**
+   Constraints bottom-trailing of the view to its parent's.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter trailing: A CGFloat offset for trailing.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottomTrailing(bottom: CGFloat = 0, trailing: CGFloat = 0) -> Layout {
+    return constraint(.bottomTrailing, constants: -bottom, -trailing)
+  }
+  
+  /**
+   Constraints leading and trailing of the view to its parent's.
+   - Parameter leading: A CGFloat offset for leading.
+   - Parameter trailing: A CGFloat offset for trailing.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func leadingTrailing(leading: CGFloat = 0, trailing: CGFloat = 0) -> Layout {
+    return constraint(.leadingTrailing, constants: leading, -trailing)
   }
   
   /**
@@ -321,6 +396,28 @@ public extension Layout {
   }
   
   /**
+   Constraints leading of the view to the given anchor.
+   - Parameter _ anchor: A LayoutAnchorable.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func leading(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.leading, to: anchor, constant: offset)
+  }
+  
+  /**
+   Constraints trailing of the view to the given anchor.
+   - Parameter _ anchor: A LayoutAnchorable.
+   - Parameter _ offset: A CGFloat offset.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func trailing(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
+    return constraint(.trailing, to: anchor, constant: -offset)
+  }
+  
+  /**
    Constraints bottom of the view to the given anchor.
    - Parameter _ anchor: A LayoutAnchorable.
    - Parameter _ offset: A CGFloat offset.
@@ -329,6 +426,66 @@ public extension Layout {
   @discardableResult
   func bottom(_ anchor: LayoutAnchorable, _ offset: CGFloat = 0) -> Layout {
     return constraint(.bottom, to: anchor, constant: -offset)
+  }
+  
+  /**
+   Constraints top-leading of the view to the given anchor.
+   - Parameter _ anchor: A LayoutAnchorable.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter leading: A CGFloat offset for leading.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topLeading(_ anchor: LayoutAnchorable, top: CGFloat = 0, leading: CGFloat = 0) -> Layout {
+    return constraint(.topLeading, to: anchor, constants: top, leading)
+  }
+  
+  /**
+   Constraints top-trailing of the view to the given anchor.
+   - Parameter _ anchor: A LayoutAnchorable.
+   - Parameter top: A CGFloat offset for top.
+   - Parameter trailing: A CGFloat offset for trailing.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func topTrailing(_ anchor: LayoutAnchorable, top: CGFloat = 0, trailing: CGFloat = 0) -> Layout {
+    return constraint(.topTrailing, to: anchor, constants: top, -trailing)
+  }
+  
+  /**
+   Constraints bottom-leading of the view to the given anchor.
+   - Parameter _ anchor: A LayoutAnchorable.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter leading: A CGFloat offset for leading.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottomLeading(_ anchor: LayoutAnchorable, bottom: CGFloat = 0, leading: CGFloat = 0) -> Layout {
+    return constraint(.bottomLeading, to: anchor, constants: -bottom, leading)
+  }
+  
+  /**
+   Constraints bottom-trailing of the view to the given anchor.
+   - Parameter _ anchor: A LayoutAnchorable.
+   - Parameter bottom: A CGFloat offset for bottom.
+   - Parameter trailing: A CGFloat offset for trailing.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func bottomTrailing(_ anchor: LayoutAnchorable, bottom: CGFloat = 0, trailing: CGFloat = 0) -> Layout {
+    return constraint(.bottomTrailing, to: anchor, constants: -bottom, -trailing)
+  }
+  
+  /**
+   Constraints leading and trailing of the view to the given anchor.
+   - Parameter _ anchor: A LayoutAnchorable.
+   - Parameter leading: A CGFloat offset for leading.
+   - Parameter trailing: A CGFloat offset for trailing.
+   - Returns: A Layout instance to allow chaining.
+   */
+  @discardableResult
+  func leadingTrailing(_ anchor: LayoutAnchorable, leading: CGFloat = 0, trailing: CGFloat = 0) -> Layout {
+    return constraint(.leadingTrailing, to: anchor, constants: leading, -trailing)
   }
   
   /**

--- a/Sources/iOS/LayoutAnchor.swift
+++ b/Sources/iOS/LayoutAnchor.swift
@@ -51,81 +51,81 @@ public struct LayoutAnchor {
 public extension Layout {
   /// A layout anchor representing top of the view.
   var top: LayoutAnchor {
-    return attribute(.top)
+    return anchor(.top)
   }
   
   /// A layout anchor representing bottom of the view.
   var bottom: LayoutAnchor {
-    return attribute(.bottom)
+    return anchor(.bottom)
   }
   
   /// A layout anchor representing left of the view.
   var left: LayoutAnchor {
-    return attribute(.left)
+    return anchor(.left)
   }
   
   /// A layout anchor representing right of the view.
   var right: LayoutAnchor {
-    return attribute(.right)
+    return anchor(.right)
   }
   
   /// A layout anchor representing top-left of the view.
   var topLeft: LayoutAnchor {
-    return attribute(.topLeft)
+    return acnhor(.topLeft)
   }
   
   /// A layout anchor representing top-right of the view.
   var topRight: LayoutAnchor {
-    return attribute(.topRight)
+    return acnhor(.topRight)
   }
   
   /// A layout anchor representing bottom-left of the view.
   var bottomLeft: LayoutAnchor {
-    return attribute(.bottomLeft)
+    return acnhor(.bottomLeft)
   }
   
   /// A layout anchor representing bottom-right of the view.
   var bottomRight: LayoutAnchor {
-    return attribute(.bottomRight)
+    return acnhor(.bottomRight)
   }
   
   /// A layout anchor representing top and bottom of the view.
   var topBottom: LayoutAnchor {
-    return attribute(.topBottom)
+    return acnhor(.topBottom)
   }
   
   /// A layout anchor representing left and right of the view.
   var leftRight: LayoutAnchor {
-    return attribute(.leftRight)
+    return acnhor(.leftRight)
   }
   
   /// A layout anchor representing center of the view.
   var center: LayoutAnchor {
-    return attribute(.center)
+    return acnhor(.center)
   }
   
   /// A layout anchor representing horizontal center of the view.
   var centerX: LayoutAnchor {
-    return attribute(.centerX)
+    return anchor(.centerX)
   }
   
   /// A layout anchor representing vertical center of the view.
   var centerY: LayoutAnchor {
-    return attribute(.centerY)
+    return anchor(.centerY)
   }
   
   /// A layout anchor representing top, left, bottom and right of the view.
   var edges: LayoutAnchor {
-    return attribute(.edges)
+    return acnhor(.edges)
   }
   
   /// A layout anchor representing width of the view.
   var width: LayoutAnchor {
-    return attribute(.width)
+    return anchor(.width)
   }
   /// A layout anchor representing height of the view.
   var height: LayoutAnchor {
-    return attribute(.height)
+    return anchor(.height)
   }
 }
 
@@ -135,7 +135,7 @@ private extension Layout {
    - Parameter attribute: A LayoutAttribute.
    - Returns: A LayoutAnchor.
    */
-  func attribute(_ attribute: LayoutAttribute) -> LayoutAnchor {
+  func anchor(_ attribute: LayoutAttribute) -> LayoutAnchor {
     return LayoutAnchor(view: view, attributes: [attribute])
   }
   
@@ -144,7 +144,7 @@ private extension Layout {
    - Parameter attributes: An array of LayoutAttribute.
    - Returns: A LayoutAnchor.
    */
-  func attribute(_ attributes: [LayoutAttribute]) -> LayoutAnchor {
+  func acnhor(_ attributes: [LayoutAttribute]) -> LayoutAnchor {
     return LayoutAnchor(view: view, attributes: attributes)
   }
 }

--- a/Sources/iOS/LayoutAnchor.swift
+++ b/Sources/iOS/LayoutAnchor.swift
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2015 - 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import UIKit
+
+public struct LayoutAnchor {
+  /// A weak reference to the view.
+  weak var view: UIView?
+  
+  /// An array of LayoutAttribute for the view.
+  let attributes: [LayoutAttribute]
+  
+  /**
+   An initializer taking view and anchor attributes.
+   - Parameter view: A UIView.
+   - Parameter attributes: An array of LayoutAtrribute.
+  */
+  init(view: UIView?, attributes: [LayoutAttribute]) {
+    self.view = view
+    self.attributes = attributes
+  }
+}
+
+public extension Layout {
+  /// A layout anchor representing top of the view.
+  var top: LayoutAnchor {
+    return attribute(.top)
+  }
+  
+  /// A layout anchor representing bottom of the view.
+  var bottom: LayoutAnchor {
+    return attribute(.bottom)
+  }
+  
+  /// A layout anchor representing left of the view.
+  var left: LayoutAnchor {
+    return attribute(.left)
+  }
+  
+  /// A layout anchor representing right of the view.
+  var right: LayoutAnchor {
+    return attribute(.right)
+  }
+  
+  /// A layout anchor representing top-left of the view.
+  var topLeft: LayoutAnchor {
+    return attribute(.topLeft)
+  }
+  
+  /// A layout anchor representing top-right of the view.
+  var topRight: LayoutAnchor {
+    return attribute(.topRight)
+  }
+  
+  /// A layout anchor representing bottom-left of the view.
+  var bottomLeft: LayoutAnchor {
+    return attribute(.bottomLeft)
+  }
+  
+  /// A layout anchor representing bottom-right of the view.
+  var bottomRight: LayoutAnchor {
+    return attribute(.bottomRight)
+  }
+  
+  /// A layout anchor representing top and bottom of the view.
+  var topBottom: LayoutAnchor {
+    return attribute(.topBottom)
+  }
+  
+  /// A layout anchor representing left and right of the view.
+  var leftRight: LayoutAnchor {
+    return attribute(.leftRight)
+  }
+  
+  /// A layout anchor representing center of the view.
+  var center: LayoutAnchor {
+    return attribute(.center)
+  }
+  
+  /// A layout anchor representing horizontal center of the view.
+  var centerX: LayoutAnchor {
+    return attribute(.centerX)
+  }
+  
+  /// A layout anchor representing vertical center of the view.
+  var centerY: LayoutAnchor {
+    return attribute(.centerY)
+  }
+  
+  /// A layout anchor representing top, left, bottom and right of the view.
+  var edges: LayoutAnchor {
+    return attribute(.edges)
+  }
+  
+  /// A layout anchor representing width of the view.
+  var width: LayoutAnchor {
+    return attribute(.width)
+  }
+  /// A layout anchor representing height of the view.
+  var height: LayoutAnchor {
+    return attribute(.height)
+  }
+}
+
+private extension Layout {
+  /**
+   Creates LayoutAnchor with the given attribute.
+   - Parameter attribute: A LayoutAttribute.
+   - Returns: A LayoutAnchor.
+   */
+  func attribute(_ attribute: LayoutAttribute) -> LayoutAnchor {
+    return LayoutAnchor(view: view, attributes: [attribute])
+  }
+  
+  /**
+   Creates LayoutAnchor with the given attributes.
+   - Parameter attributes: An array of LayoutAttribute.
+   - Returns: A LayoutAnchor.
+   */
+  func attribute(_ attributes: [LayoutAttribute]) -> LayoutAnchor {
+    return LayoutAnchor(view: view, attributes: attributes)
+  }
+}

--- a/Sources/iOS/LayoutAnchor.swift
+++ b/Sources/iOS/LayoutAnchor.swift
@@ -76,6 +76,16 @@ public extension LayoutAnchor {
     return anchor(.right)
   }
   
+  /// A layout anchor representing leading of the view.
+  var leading: LayoutAnchor {
+    return anchor(.leading)
+  }
+  
+  /// A layout anchor representing trailing of the view.
+  var trailing: LayoutAnchor {
+    return anchor(.trailing)
+  }
+  
   /// A layout anchor representing top-left of the view.
   var topLeft: LayoutAnchor {
     return acnhor(.topLeft)
@@ -96,6 +106,26 @@ public extension LayoutAnchor {
     return acnhor(.bottomRight)
   }
   
+  /// A layout anchor representing top-leading of the view.
+  var topLeading: LayoutAnchor {
+    return acnhor(.topLeading)
+  }
+  
+  /// A layout anchor representing top-trailing of the view.
+  var topTrailing: LayoutAnchor {
+    return acnhor(.topTrailing)
+  }
+  
+  /// A layout anchor representing bottom-leading of the view.
+  var bottomLeading: LayoutAnchor {
+    return acnhor(.bottomLeading)
+  }
+  
+  /// A layout anchor representing bottom-trailing of the view.
+  var bottomTrailing: LayoutAnchor {
+    return acnhor(.bottomTrailing)
+  }
+  
   /// A layout anchor representing top and bottom of the view.
   var topBottom: LayoutAnchor {
     return acnhor(.topBottom)
@@ -104,6 +134,11 @@ public extension LayoutAnchor {
   /// A layout anchor representing left and right of the view.
   var leftRight: LayoutAnchor {
     return acnhor(.leftRight)
+  }
+  
+  /// A layout anchor representing leading and trailing of the view.
+  var leadingTrailing: LayoutAnchor {
+    return acnhor(.leadingTrailing)
   }
   
   /// A layout anchor representing center of the view.

--- a/Sources/iOS/LayoutAnchor.swift
+++ b/Sources/iOS/LayoutAnchor.swift
@@ -30,15 +30,16 @@
 
 import UIKit
 
-/// A protocol that's conformed by UIView and LayoutAnchor.
+/// A protocol that's conformed by UIView, LayoutAnchor, and Layout.
 public protocol LayoutAnchorable { }
 
 extension UIView: LayoutAnchorable { }
+extension Layout: LayoutAnchorable { }
 extension LayoutAnchor: LayoutAnchorable { }
 
 public struct LayoutAnchor {
   /// A weak reference to the view.
-  weak var view: UIView?
+  weak var view: Layoutable?
   
   /// An array of LayoutAttribute for the view.
   let attributes: [LayoutAttribute]
@@ -48,7 +49,7 @@ public struct LayoutAnchor {
    - Parameter view: A UIView.
    - Parameter attributes: An array of LayoutAtrribute.
   */
-  init(view: UIView?, attributes: [LayoutAttribute]) {
+  init(view: Layoutable?, attributes: [LayoutAttribute]) {
     self.view = view
     self.attributes = attributes
   }

--- a/Sources/iOS/LayoutAnchor.swift
+++ b/Sources/iOS/LayoutAnchor.swift
@@ -49,13 +49,13 @@ public struct LayoutAnchor {
    - Parameter view: A Constraintable.
    - Parameter attributes: An array of LayoutAtrribute.
   */
-  init(constraintable: Constraintable?, attributes: [LayoutAttribute]) {
+  init(constraintable: Constraintable?, attributes: [LayoutAttribute] = []) {
     self.constraintable = constraintable
     self.attributes = attributes
   }
 }
 
-public extension Layout {
+public extension LayoutAnchor {
   /// A layout anchor representing top of the view.
   var top: LayoutAnchor {
     return anchor(.top)
@@ -136,7 +136,7 @@ public extension Layout {
   }
 }
 
-private extension Layout {
+private extension LayoutAnchor {
   /**
    Creates LayoutAnchor with the given attribute.
    - Parameter attribute: A LayoutAttribute.

--- a/Sources/iOS/LayoutAnchor.swift
+++ b/Sources/iOS/LayoutAnchor.swift
@@ -30,6 +30,12 @@
 
 import UIKit
 
+/// A protocol that's conformed by UIView and LayoutAnchor.
+public protocol LayoutAnchorable { }
+
+extension UIView: LayoutAnchorable { }
+extension LayoutAnchor: LayoutAnchorable { }
+
 public struct LayoutAnchor {
   /// A weak reference to the view.
   weak var view: UIView?

--- a/Sources/iOS/LayoutAnchor.swift
+++ b/Sources/iOS/LayoutAnchor.swift
@@ -38,19 +38,19 @@ extension Layout: LayoutAnchorable { }
 extension LayoutAnchor: LayoutAnchorable { }
 
 public struct LayoutAnchor {
-  /// A weak reference to the view.
-  weak var view: Layoutable?
+  /// A weak reference to the constraintable.
+  weak var constraintable: Constraintable?
   
   /// An array of LayoutAttribute for the view.
   let attributes: [LayoutAttribute]
   
   /**
-   An initializer taking view and anchor attributes.
-   - Parameter view: A UIView.
+   An initializer taking constraintable and anchor attributes.
+   - Parameter view: A Constraintable.
    - Parameter attributes: An array of LayoutAtrribute.
   */
-  init(view: Layoutable?, attributes: [LayoutAttribute]) {
-    self.view = view
+  init(constraintable: Constraintable?, attributes: [LayoutAttribute]) {
+    self.constraintable = constraintable
     self.attributes = attributes
   }
 }
@@ -143,7 +143,7 @@ private extension Layout {
    - Returns: A LayoutAnchor.
    */
   func anchor(_ attribute: LayoutAttribute) -> LayoutAnchor {
-    return LayoutAnchor(view: view, attributes: [attribute])
+    return LayoutAnchor(constraintable: constraintable, attributes: [attribute])
   }
   
   /**
@@ -152,6 +152,6 @@ private extension Layout {
    - Returns: A LayoutAnchor.
    */
   func acnhor(_ attributes: [LayoutAttribute]) -> LayoutAnchor {
-    return LayoutAnchor(view: view, attributes: attributes)
+    return LayoutAnchor(constraintable: constraintable, attributes: attributes)
   }
 }

--- a/Sources/iOS/LayoutAttribute.swift
+++ b/Sources/iOS/LayoutAttribute.swift
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2015 - 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import UIKit
+
+/// A typealias for NSLayoutConstraint.Attribute
+internal typealias LayoutAttribute = NSLayoutConstraint.Attribute
+
+internal extension Array where Element == LayoutAttribute {
+  /// A LayoutAttribute array containing top and left.
+  static var topLeft: [LayoutAttribute] {
+    return [.top, .left]
+  }
+  
+  /// A LayoutAttribute array containing top and right.
+  static var topRight: [LayoutAttribute] {
+    return [.top, .right]
+  }
+  
+  /// A LayoutAttribute array containing bottom and left.
+  static var bottomLeft: [LayoutAttribute] {
+    return [.bottom, .left]
+  }
+  
+  /// A LayoutAttribute array containing bottom and right.
+  static var bottomRight: [LayoutAttribute] {
+    return [.bottom, .right]
+  }
+  
+  /// A LayoutAttribute array containing left and right.
+  static var leftRight: [LayoutAttribute] {
+    return [.left, .right]
+  }
+  
+  /// A LayoutAttribute array containing top and bottom.
+  static var topBottom: [LayoutAttribute] {
+    return [.top, .bottom]
+  }
+  
+  /// A LayoutAttribute array containing centerX and centerY.
+  static var center: [LayoutAttribute] {
+    return [.centerX, .centerY]
+  }
+  
+  /// A LayoutAttribute array containing top, left, bottom and right.
+  static var edges: [LayoutAttribute] {
+    return [.top, .left, .bottom, .right]
+  }
+  
+  /// A LayoutAttribute array for constant height.
+  static var constantHeight: [LayoutAttribute] {
+    return [.height, .notAnAttribute]
+  }
+  
+  /// A LayoutAttribute array for constant width.
+  static var constantWidth: [LayoutAttribute] {
+    return [.width, .notAnAttribute]
+  }
+}

--- a/Sources/iOS/LayoutAttribute.swift
+++ b/Sources/iOS/LayoutAttribute.swift
@@ -59,6 +59,31 @@ internal extension Array where Element == LayoutAttribute {
     return [.left, .right]
   }
   
+  /// A LayoutAttribute array containing top and leading.
+  static var topLeading: [LayoutAttribute] {
+    return [.top, .leading]
+  }
+  
+  /// A LayoutAttribute array containing top and trailing.
+  static var topTrailing: [LayoutAttribute] {
+    return [.top, .trailing]
+  }
+  
+  /// A LayoutAttribute array containing bottom and leading.
+  static var bottomLeading: [LayoutAttribute] {
+    return [.bottom, .leading]
+  }
+  
+  /// A LayoutAttribute array containing bottom and trailing.
+  static var bottomTrailing: [LayoutAttribute] {
+    return [.bottom, .trailing]
+  }
+  
+  /// A LayoutAttribute array containing left and trailing.
+  static var leadingTrailing: [LayoutAttribute] {
+    return [.leading, .trailing]
+  }
+  
   /// A LayoutAttribute array containing top and bottom.
   static var topBottom: [LayoutAttribute] {
     return [.top, .bottom]

--- a/Sources/iOS/LayoutConstraint.swift
+++ b/Sources/iOS/LayoutConstraint.swift
@@ -67,10 +67,10 @@ internal extension LayoutConstraint {
     var v: [NSLayoutConstraint] = []
     
     zip(zip(fromAnchor.attributes, toAnchor.attributes), constants).forEach {
-      v.append(NSLayoutConstraint(item: fromAnchor.view as Any,
+      v.append(NSLayoutConstraint(item: fromAnchor.constraintable as Any,
                                   attribute: $0.0,
                                   relatedBy: .equal,
-                                  toItem: toAnchor.view,
+                                  toItem: toAnchor.constraintable,
                                   attribute: $0.1,
                                   multiplier: 1,
                                   constant: $1))

--- a/Sources/iOS/LayoutConstraint.swift
+++ b/Sources/iOS/LayoutConstraint.swift
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 - 2018, Daniel Dahan and CosmicMind, Inc. <http://cosmicmind.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of CosmicMind nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import UIKit
+
+internal struct LayoutConstraint {
+  /// `From` anchor for the constraint.
+  private let fromAnchor: LayoutAnchor
+  
+  /// `To` anchor for the constraint.
+  private let toAnchor: LayoutAnchor
+  
+  /// An array of constants for the constraint.
+  private var constants: [CGFloat]
+  
+  /**
+   An initializer taking `from` and `to` anchors and constants for the constraint.
+   - Parameter fromAnchor: A LayoutAnchor.
+   - Parameter toAnchor: A LayoutAnchor.
+   - Parameter constants: An array of CGFloat.
+   */
+  init(fromAnchor: LayoutAnchor, toAnchor: LayoutAnchor, constants: [CGFloat]) {
+    self.fromAnchor = fromAnchor
+    self.toAnchor = toAnchor
+    self.constants = constants
+  }
+}
+
+internal extension LayoutConstraint {
+  /// Creates an array of NSLayoutConstraint from a LayoutConstraint.
+  var constraints: [NSLayoutConstraint] {
+    guard fromAnchor.attributes.count == toAnchor.attributes.count else {
+      fatalError("[Material Error: The number of attributes of anchors does not match.]")
+    }
+    
+    guard fromAnchor.attributes.count == constants.count else {
+      fatalError("[Material Error: The number of constants does not match the number of constraints.]")
+    }
+    
+    var v: [NSLayoutConstraint] = []
+    
+    zip(zip(fromAnchor.attributes, toAnchor.attributes), constants).forEach {
+      v.append(NSLayoutConstraint(item: fromAnchor.view as Any,
+                                  attribute: $0.0,
+                                  relatedBy: .equal,
+                                  toItem: toAnchor.view,
+                                  attribute: $0.1,
+                                  multiplier: 1,
+                                  constant: $1))
+    }
+    
+    
+    return v
+  }
+}


### PR DESCRIPTION
# Layout

Working directly with `NSLayoutConstraint` or `NSLayoutAnchor` is pretty tedious. Material gives a simple API to create and update constraints easily. 

`layout`code will add `childView` to `parentView` and return instance of `Layout`:

```swift
parentView.layout(childView)
```

`Layout` has completely chainable API to set constraints fluently. For example, to make a `childView` have the constant height of `32`, half of the width of its parent plus 20 point, 10 points below `anotherView`'s bottom and in the horizontal center of its parent you just do:

```swift
parentView.layout(childView)
  .height(32) // constant height of 32
  .width(offset: 20).multiply(0.5) // parentWidth * 0.5 + 20
  .centerX() // center in parent in X coordinate
  .top(anotherView.anchor.bottom, 10) // anotherView's bottom + 10
```

## List of available methods

`Layout` has following methods to set constraints in relation with parent and all takes optional offset argument:

```swift
top(_ offset:) // Constraints top of the view to its parent's. 
left(_ offset:) // Constraints left of the view to its parent's. 
right(_ offset:) // Constraints right of the view to its parent. 
leading(_ offset:) // Constraints leading of the view to its parent's. 
trailing(_ offset:) // Constraints trailing of the view to its parent. 
bottom(_ offset:) // Constraints bottom of the view to its parent's. 
topLeft(top:, left:) // Constraints top-left of the view to its parent's. 
topRight(top:, right:) // Constraints top-right of the view to its parent's. 
bottomLeft(bottom:, left:) // Constraints bottom-left of the view to its parent's. 
bottomRight(bottom:, right:) // Constraints bottom-right of the view to its parent's. 
leftRight(left:, right:) // Constraints left and right of the view to its parent's. 
topLeading(top:, leading:) // Constraints top-leading of the view to its parent's. 
topTrailing(top:, trailing:) // Constraints top-trailing of the view to its parent's. 
bottomLeading(bottom:, leading:) // Constraints bottom-leading of the view to its parent's. 
bottomTrailing(bottom:, trailing:) // Constraints bottom-trailing of the view to its parent's. 
leadingTrailing(leading:, trailing:) // Constraints leading and trailing of the view to its parent's. 
topBottom(top:, bottom:) // Constraints top and bottom of the view to its parent's. 
center(offsetX:, offsetY:) // Constraints center of the view to its parent's. 
centerX(_ offset:) // Constraints horizontal center of the view to its parent's. 
centerY(_ offset:) // Constraints vertical center of the view to its parent's. 
width(offset:) // Constraints width of the view to its parent's. 
height(offset:) // Constraints height of the view to its parent's. 
edges(top:, left:, bottom:, right:) // Constraints edges of the view to its parent's. 

```


## Methods for `width` and `height`

There are 2 additional methods for setting constant height and width: 
```swift
width(_ width:) // Constraints width of the view to a constant value. 
height(_ height:) // Constraints height of the view to a constant value. 
```

If you noticed there are 2 methods for `width` and `height`:

```swift
width(offset:) // Constraints width of the view to its parent's. 
height(offset:) // Constraints height of the view to its parent's.

width(_ width:) // Constraints width of the view to a constant value. 
height(_ height:) // Constraints height of the view to a constant value. 
```

The ones with `offset` are for constraining to parent and others to a constant. Following code would help to better distinguish them:

```swift
view.layout(button)
  .width(offset: 0) /// constraint to parent with offset 0.
  .width() /// same as above.
  .width(10) /// constraint to a constant value 10.
```
Mehtods other than `width` and `height` does not take `offset:` as named parameter take value, rather they are marked with `_` just like constant `width/height`:
```swift
  .top(0) /// constraint to parent with offset 0. No `offset:`
  .top() /// same as above.
```



# Anchors

To create constraints in relation to other view, `LayoutAnchor` can be used. All methods available for set constraints between child and parent are also available for anchoring on `Layout`:

```swift
top(_ anchor:, _ offset:) // Constraints top of the view to the given anchor. 
left(_ anchor:, _ offset:) // Constraints left of the view to the given anchor. 
right(_ anchor:, _ offset:) // Constraints right of the view to the given anchor. 
leading(_ anchor:, _ offset:) // Constraints leading of the view to the given anchor. 
trailing(_ anchor:, _ offset:) // Constraints trailing of the view to the given anchor. 
bottom(_ anchor:, _ offset:) // Constraints bottom of the view to the given anchor. 
topLeading(_ anchor:, top:, leading:) // Constraints top-leading of the view to the given anchor. 
topTrailing(_ anchor:, top:, trailing:) // Constraints top-trailing of the view to the given anchor. 
bottomLeading(_ anchor:, bottom:, leading:) // Constraints bottom-leading of the view to the given anchor. 
bottomTrailing(_ anchor:, bottom:, trailing:) // Constraints bottom-trailing of the view to the given anchor. 
leadingTrailing(_ anchor:, leading:, trailing:) // Constraints leading and trailing of the view to the given anchor. 
topLeft(_ anchor:, top:, left:) // Constraints top-left of the view to the given anchor. 
topRight(_ anchor:, top:, right:) // Constraints top-right of the view to the given anchor. 
bottomLeft(_ anchor:, bottom:, left:) // Constraints bottom-left of the view to the given anchor. 
bottomRight(_ anchor:, bottom:, right:) // Constraints bottom-right of the view to the given anchor. 
leftRight(_ anchor:, left:, right:) // Constraints left and right of the view to the given anchor. 
topBottom(_ anchor:, top:, bottom:) // Constraints top and bottom of the view to the given anchor. 
center(_ anchor:, offsetX:, offsetY:) // Constraints center of the view to the given anchor. 
centerX(_ anchor:, _ offset:) // Constraints horizontal center of the view to the given anchor. 
centerY(_ anchor:, _ offset:) // Constraints vertical center of the view to the given anchor. 
width(_ anchor:, _ offset:) // Constraints height of the view to the given anchor. 
height(_ anchor:, _ offset:) // Constraints height of the view to the given anchor. 
edges(_ anchor:, top:, left:, bottom:, right:) // Constraints edges of the view to the given anchor. 

```

Anchor of a view can be accessed via `view.anchor`:

```swift
view.layout(button)
  .top(anotherView.anchor.bottom, 10) // anotherView's bottom + 10
```

## List of available anchors:

```swift
.top // A layout anchor representing top of the view.
.bottom // A layout anchor representing bottom of the view.
.left // A layout anchor representing left of the view.
.right // A layout anchor representing right of the view.
.leading // A layout anchor representing leading of the view.
.trailing // A layout anchor representing trailing of the view.
.topLeft // A layout anchor representing top-left of the view.
.topRight // A layout anchor representing top-right of the view.
.bottomLeft // A layout anchor representing bottom-left of the view.
.bottomRight // A layout anchor representing bottom-right of the view.
.topLeading // A layout anchor representing top-leading of the view.
.topTrailing // A layout anchor representing top-trailing of the view.
.bottomLeading // A layout anchor representing bottom-leading of the view.
.bottomTrailing // A layout anchor representing bottom-trailing of the view.
.topBottom // A layout anchor representing top and bottom of the view.
.leftRight // A layout anchor representing left and right of the view.
.leadingTrailing // A layout anchor representing leading and trailing of the view.
.center // A layout anchor representing center of the view.
.centerX // A layout anchor representing horizontal center of the view.
.centerY // A layout anchor representing vertical center of the view.
.edges // A layout anchor representing top, left, bottom and right of the view.
.width // A layout anchor representing width of the view.
.height // A layout anchor representing height of the view.
```

### Safe Anchor

For pinning to the `safeAreaLayoutGuide` of a view, instead of `view.anchor`, `view.safeAnchor` can be used. For below iOS 11, `view.safeAnchor` will fall back to use `view.anchor`.

```swift
view.layout(button)
  .leading(view.safeAnchor.leading)
```

# Omitting anchors

Anchors can be omitted if they are same as the anchor that's being pinned:

```swift
view.layout(button1)
  .width(button2.anchor.width)
  .width(button2) // same as above
```

Same applies to `safeAnchor` as well:

```swift
view.layout(button1)
	.width(view.safeAnchor.width)
  .width(view.safeAnchor) // same as above
```

# Compound constraints

Some constraints such as `edges` and `center` are composed of multiple constraints. For example `edges` creates 4 constraints. Those constrains can be used together with anchors:

```swift
view.layout(button)
  .center() // pin to the center of parent same as centerX().centerY()
  .topLeft(button2.anchor.bottomRight) // button.top = button2.bottom and bottom.left = bottom.right.
  .edges(view2) /// equal to view2's top left bottom right.
```



# Priority and multiplier

Priority and multiplier of be set using `priority()` and `multiply()` methods respectively:

```swift
view.layout(button)
  .width().multiply(0.5) /// CGFloat multiplier
          .priority(100) /// Float
  .height(32).priority(.defaultLow) /// UILayoutPriority
```

## Limitations

`priority()` and `multiply()` methods can only be used to set last created constraint. For example, `edges()` creates 4 constraints and the last one is right constraint, so `priority()` and `multiply()` will be effective on only it. You have to explicitly delare

```swift
view.layout(button).edges()
  .multiply(0.5) // only right constraint gets multiplier 0.5
```

# Updating constraints

`Layout` will update the constant of the constraint if it exists:

```swift
view.layout(button)
.top()

DispatchQueue.main.asyncAfter(deadline: .now() + 1) { // after 1 second.
  self.view.layout(button)
    .top(20) /// Update the constant of top constraint instead of creating new one.

  UIView.animate(withDuration: 0.25, animations: self.view.layoutSubviews) // animate change
}
```





# Relation

Only `NSLayoutConstraint.Relation.equal` is supported right now, `lessThanOrEqual` and `greaterThanOrEqual` is not supported yet.



# Some highlights of changes

- Renaming:
  - `centerHorizontally(offset:)` -> `centerX(offset:)`
  - `centerVertically(offset:)` -> `centerY(offset:)`
  - `horizontally(left:, right:)` -> `leftRight(left:, right:)`
  - `vertically(top:, bottom:)` -> `topBottom(top:, bottom:)`

- Removed:
  - `size(_ size:)`
  - `horizontally(_ children:, left:, right:, interimSpace:)`
  - `vertically(_ children:, top:, bottom:, interimSpace:,`




#### Sample app
[Button.zip](https://github.com/CosmicMind/Material/files/2531991/Button.zip)
See `ButtonViewController.swift` line `36`
