### PR TITLE
Ignore Carthage checkouts folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ profile
 DerivedData
 Index
 Build
-
+Checkouts


### PR DESCRIPTION
Adding `Carthage/Checkouts` folder to `.gitignore` allow Carthage users to use the `--use-submodules` option and keep a clean local copy