### PR TITLE
Fix Layout Documentation for Width Constraint

### DIFF
--- a/Sources/iOS/Layout/Layout.swift
+++ b/Sources/iOS/Layout/Layout.swift
@@ -918,7 +918,7 @@ public extension Layout {
   }
   
   /**
-   Constraints height of the view to the given anchor.
+   Constraints width of the view to the given anchor.
    - Parameter _ anchor: A LayoutAnchorable.
    - Parameter offset: A CGFloat offset.
    - Returns: A Layout instance to allow chaining.


### PR DESCRIPTION
* The function documentation incorrectly stated "height" instead of "width"