### PR TITLE
Fixed status bar visibility and style was not controlled by rootViewController

### DIFF
--- a/Sources/iOS/Table/TableViewController.swift
+++ b/Sources/iOS/Table/TableViewController.swift
@@ -69,6 +69,7 @@ extension TableViewController {
   fileprivate func prepareTableView() {
     tableView.delegate = self
     tableView.dataSource = self
+    tableView.backgroundColor = .clear
     view.layout(tableView).edges()
   }
 }

--- a/Sources/iOS/Transition/TransitionController.swift
+++ b/Sources/iOS/Transition/TransitionController.swift
@@ -59,6 +59,14 @@ open class TransitionController: ViewController {
     return childForStatusBarStyle
   }
   
+  open override var childForHomeIndicatorAutoHidden: UIViewController? {
+    return childForStatusBarStyle
+  }
+  
+  open override var childForScreenEdgesDeferringSystemGestures: UIViewController? {
+    return childForStatusBarStyle
+  }
+  
   /// A reference to the container view.
   @IBInspectable
   public let container = UIView()

--- a/Sources/iOS/Transition/TransitionController.swift
+++ b/Sources/iOS/Transition/TransitionController.swift
@@ -46,6 +46,19 @@ open class TransitionController: ViewController {
     }
   }
   
+  /// A Boolean indicating whether the controller is in transitioning state.
+  open var isTransitioning: Bool {
+    return MotionTransition.shared.isTransitioning && MotionTransition.shared.fromViewController == rootViewController
+  }
+  
+  open override var childForStatusBarStyle: UIViewController? {
+    return isTransitioning ? MotionTransition.shared.toViewController ?? rootViewController : rootViewController
+  }
+  
+  open override var childForStatusBarHidden: UIViewController? {
+    return childForStatusBarStyle
+  }
+  
   /// A reference to the container view.
   @IBInspectable
   public let container = UIView()


### PR DESCRIPTION
With the following hierarchy:
```swift
TransitionController(rootViewController: MyViewController())
```
Where `MyViewController` is: 
```swift
class MyViewController: UIViewController {
  override var prefersStatusBarHidden: Bool {
    return true
  }
  
  override var preferredStatusBarStyle: UIStatusBarStyle {
    return .lightContent
  }
  
  override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
    return .slide
  }
  override var preferredScreenEdgesDeferringSystemGestures: UIRectEdge {
    return .all
  }
  
  override var prefersHomeIndicatorAutoHidden: Bool {
    return false
  }
}
```

None of the above overrides is respected (all are ignored) because `TransitionController` has more precedence. This PR fixes that by returning `rootViewController` (or new rootViewController during transition) in `childForXXXX` properties.

#### Migration (Likelihood Of Impact: Medium)
This fix might result in some unexpected status bar behaviors if someone were overriding those methods in direct or undirect (`TabsController`, `NavigationDrawerController`) subclass of `TransitionController`.
- Option 1 (recommended): Move your overrides to child view controllers.
- Option 2: Re-override the properties to return nil. Overriding just `childForStatusBarStyle` should be enough:
```swift
class MySubclassOfTrantionController: TransitionController { /// or TabsController, NavigationDrawerController etc.
  override var childForStatusBarStyle: UIViewController? {
    return nil
  }

  ...
}
```