### PR TITLE
Made Switch more customizable 

### DIFF
--- a/Sources/iOS/Switch/Switch.swift
+++ b/Sources/iOS/Switch/Switch.swift
@@ -36,11 +36,11 @@ public enum SwitchState: Int {
   case off
 }
 
-@objc(SwitchSize)
-public enum SwitchSize: Int {
+public enum SwitchSize {
   case small
   case medium
   case large
+  case custom(width: CGFloat, height: CGFloat)
 }
 
 @objc(SwitchDelegate)
@@ -248,9 +248,11 @@ open class Switch: UIControl, Themeable {
       case .large:
         trackThickness = 24
         buttonDiameter = 28
+      case .custom:
+        break
       }
       
-      frame.size = intrinsicContentSize
+      invalidateIntrinsicContentSize()
     }
   }
   
@@ -262,6 +264,8 @@ open class Switch: UIControl, Themeable {
       return CGSize(width: 38, height: 38)
     case .large:
       return CGSize(width: 42, height: 42)
+    case .custom(let width, let height):
+      return CGSize(width: width, height: height)
     }
   }
   

--- a/Sources/iOS/Switch/Switch.swift
+++ b/Sources/iOS/Switch/Switch.swift
@@ -63,10 +63,18 @@ open class Switch: UIControl, Themeable {
   fileprivate var internalSwitchState = SwitchState.off
   
   /// Track thickness.
-  fileprivate var trackThickness: CGFloat = 0
+  open var trackThickness: CGFloat = 0 {
+    didSet {
+      layoutSubviews()
+    }
+  }
   
   /// Button diameter.
-  fileprivate var buttonDiameter: CGFloat = 0
+  open var buttonDiameter: CGFloat = 0 {
+    didSet {
+      layoutSubviews()
+    }
+  }
   
   /// Position when in the .on state.
   fileprivate var onPosition: CGFloat = 0

--- a/Sources/iOS/Switch/Switch.swift
+++ b/Sources/iOS/Switch/Switch.swift
@@ -112,6 +112,22 @@ open class Switch: UIControl, Themeable {
     }
   }
   
+  /// Button on image.
+  @IBInspectable
+  open var buttonOnImage: UIImage? {
+    didSet {
+      styleForState(state: switchState)
+    }
+  }
+  
+  /// Button off image.
+  @IBInspectable
+  open var buttonOffImage: UIImage? {
+    didSet {
+      styleForState(state: switchState)
+    }
+  }
+  
   /// Track on color.
   @IBInspectable
   open var trackOnColor = Color.clear {
@@ -159,6 +175,23 @@ open class Switch: UIControl, Themeable {
       styleForState(state: switchState)
     }
   }
+  
+  /// Button on disabled image.
+  @IBInspectable
+  open var buttonOnDisabledImage: UIImage? {
+    didSet {
+      styleForState(state: switchState)
+    }
+  }
+  
+  /// Button off disabled image.
+  @IBInspectable
+  open var buttonOffDisabledImage: UIImage? {
+    didSet {
+      styleForState(state: switchState)
+    }
+  }
+  
   
   /// Track view reference.
   open fileprivate(set) var track: UIView {
@@ -416,9 +449,11 @@ fileprivate extension Switch {
     if .on == state {
       button.backgroundColor = buttonOnColor
       track.backgroundColor = trackOnColor
+      button.image = buttonOnImage
     } else {
       button.backgroundColor = buttonOffColor
       track.backgroundColor = trackOffColor
+      button.image = buttonOffImage
     }
   }
   
@@ -430,9 +465,11 @@ fileprivate extension Switch {
     if .on == state {
       button.backgroundColor = buttonOnDisabledColor
       track.backgroundColor = trackOnDisabledColor
+      button.image = buttonOnDisabledImage
     } else {
       button.backgroundColor = buttonOffDisabledColor
       track.backgroundColor = trackOffDisabledColor
+      button.image = buttonOffDisabledImage
     }
   }
   


### PR DESCRIPTION
Added #668

- Make `trackThickness` and `buttonDiameter` accessible.
- Added `buttonOnImage` and `buttonOffImage` properties.
- Added `custom` case for SwitchSize enum.

In a nutshell, we can now do:
```swift
let s = Switch()
s.trackThickness = 24
s.buttonDiameter = 24
s.buttonOnImage = Icon.audio
s.buttonOffImage = Icon.favorite
s.switchSize = .custom(width: 50, height: 24)
```


