### PR TITLE
Fixed prepare method called twice.

### DIFF
--- a/Sources/iOS/NavigationDrawer/NavigationDrawerController.swift
+++ b/Sources/iOS/NavigationDrawer/NavigationDrawerController.swift
@@ -382,7 +382,6 @@ open class NavigationDrawerController: TransitionController {
    */
   public required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
-    prepare()
   }
   
   /**
@@ -392,7 +391,6 @@ open class NavigationDrawerController: TransitionController {
    */
   public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    prepare()
   }
   
   /**
@@ -405,7 +403,6 @@ open class NavigationDrawerController: TransitionController {
     super.init(rootViewController: rootViewController)
     self.leftViewController = leftViewController
     self.rightViewController = rightViewController
-    prepare()
   }
   
   open override func transition(to viewController: UIViewController, completion: ((Bool) -> Void)? = nil) {


### PR DESCRIPTION
Fixed issue #1215  by removing `prepare` from initializers. It should not have been called there and removing it should not cause any other problems as `prepare` method was intended to be called on `viewDidLoad`, it's kinda alias.