### PR TITLE
Update FontType protocol with RawRepresentable.

### DIFF
--- a/Sources/iOS/Font/Font.swift
+++ b/Sources/iOS/Font/Font.swift
@@ -25,27 +25,35 @@
 
 import UIKit
 
-public protocol FontType {
-  /**
-   Regular with size font.
-   - Parameter with size: A CGFLoat for the font size.
-   - Returns: A UIFont.
-   */
-  static func regular(with size: CGFloat) -> UIFont
-  
-  /**
-   Medium with size font.
-   - Parameter with size: A CGFLoat for the font size.
-   - Returns: A UIFont.
-   */
-  static func medium(with size: CGFloat) -> UIFont
-  
-  /**
-   Bold with size font.
-   - Parameter with size: A CGFLoat for the font size.
-   - Returns: A UIFont.
-   */
-  static func bold(with size: CGFloat) -> UIFont
+public protocol FontTheme {
+    static func regular(with size: CGFloat) -> UIFont
+    static func bold(with size: CGFloat) -> UIFont
+    static func medium(with size: CGFloat) -> UIFont
+}
+
+public protocol FontThemeable {
+    associatedtype Theme: FontTheme
+}
+
+public protocol FontType: RawRepresentable where RawValue == String {
+    /**
+    Font with size.
+    - Parameter value: A CGFloat for the font size.
+    - Returns: A UIFont.
+    */
+    
+    func size(_ value: CGFloat) -> UIFont
+    var font: UIFont { get }
+}
+
+public extension FontType {
+    public func size(_ value: CGFloat) -> UIFont {
+        return UIFont(name: self.rawValue, size: value)!
+    }
+
+    public var font: UIFont {
+        return self.size(Font.pointSize)
+    }
 }
 
 public struct Font {

--- a/Sources/iOS/Font/RobotoFont.swift
+++ b/Sources/iOS/Font/RobotoFont.swift
@@ -25,109 +25,54 @@
 
 import UIKit
 
-public struct RobotoFont: FontType {
-  /// Size of font.
-  public static var pointSize: CGFloat {
-    return Font.pointSize
-  }
+public enum RobotoFont: String, FontType {
+    /// Thin font.
+    case thin = "Roboto-Thin"
   
-  /// Thin font.
-  public static var thin: UIFont {
-    return thin(with: Font.pointSize)
-  }
+    /// Light font.
+    case light = "Roboto-Light"
   
-  /// Light font.
-  public static var light: UIFont {
-    return light(with: Font.pointSize)
-  }
+    /// Regular font.
+    case regular = "Roboto-Regular"
   
-  /// Regular font.
-  public static var regular: UIFont {
-    return regular(with: Font.pointSize)
-  }
+    /// Medium font.
+    case medium = "Roboto-Medium"
   
-  /// Medium font.
-  public static var medium: UIFont {
-    return medium(with: Font.pointSize)
-  }
+    /// Bold font.
+    case bold = "Roboto-Bold"
   
-  /// Bold font.
-  public static var bold: UIFont {
-    return bold(with: Font.pointSize)
-  }
-  
-  /**
-   Thin with size font.
-   - Parameter with size: A CGFLoat for the font size.
-   - Returns: A UIFont.
-   */
-  public static func thin(with size: CGFloat) -> UIFont {
-    Font.loadFontIfNeeded(name: "Roboto-Thin")
-    
-    if let f = UIFont(name: "Roboto-Thin", size: size) {
-      return f
+    /**
+    Thin with size font.
+    - Parameter with size: A CGFLoat for the font size.
+    - Returns: A UIFont.
+    */
+    public func size(_ value: CGFloat) -> UIFont {
+        Font.loadFontIfNeeded(name: self.rawValue)
+        if let f = UIFont(name: self.rawValue, size: value) {
+            return f
+        }
+
+        return Font.systemFont(ofSize: value)
     }
     
-    return Font.systemFont(ofSize: size)
-  }
-  
-  /**
-   Light with size font.
-   - Parameter with size: A CGFLoat for the font size.
-   - Returns: A UIFont.
-   */
-  public static func light(with size: CGFloat) -> UIFont {
-    Font.loadFontIfNeeded(name: "Roboto-Light")
-    
-    if let f = UIFont(name: "Roboto-Light", size: size) {
-      return f
+    /// Size of font.
+    public static var pointSize: CGFloat {
+        return Font.pointSize
     }
-    
-    return Font.systemFont(ofSize: size)
-  }
-  
-  /**
-   Regular with size font.
-   - Parameter with size: A CGFLoat for the font size.
-   - Returns: A UIFont.
-   */
-  public static func regular(with size: CGFloat) -> UIFont {
-    Font.loadFontIfNeeded(name: "Roboto-Regular")
-    
-    if let f = UIFont(name: "Roboto-Regular", size: size) {
-      return f
+}
+
+extension RobotoFont: FontThemeable {
+    public class Theme: FontTheme {
+        public static func regular(with size: CGFloat) -> UIFont {
+            return RobotoFont.regular.size(size)
+        }
+        
+        public static func bold(with size: CGFloat) -> UIFont {
+            return RobotoFont.bold.size(size)
+        }
+        
+        public static func medium(with size: CGFloat) -> UIFont {
+            return RobotoFont.medium.size(size)
+        }
     }
-    
-    return Font.systemFont(ofSize: size)
-  }
-  
-  /**
-   Medium with size font.
-   - Parameter with size: A CGFLoat for the font size.
-   - Returns: A UIFont.
-   */
-  public static func medium(with size: CGFloat) -> UIFont {
-    Font.loadFontIfNeeded(name: "Roboto-Medium")
-    
-    if let f = UIFont(name: "Roboto-Medium", size: size) {
-      return f
-    }
-    
-    return Font.boldSystemFont(ofSize: size)
-  }
-  
-  /**
-   Bold with size font.
-   - Parameter with size: A CGFLoat for the font size.
-   - Returns: A UIFont.
-   */
-  public static func bold(with size: CGFloat) -> UIFont {
-    Font.loadFontIfNeeded(name: "Roboto-Bold")
-    
-    if let f = UIFont(name: "Roboto-Bold", size: size) {
-      return f
-    }
-    
-    return Font.boldSystemFont(ofSize: size)
-  }
 }

--- a/Sources/iOS/Theme/Theme.swift
+++ b/Sources/iOS/Theme/Theme.swift
@@ -73,7 +73,7 @@ public struct Theme: Hashable {
   public static var isEnabled = false
   
   /// Global font for app.
-  public static var font: FontType.Type = RobotoFont.self
+  public private(set) static var font: FontTheme.Type = RobotoFont.Theme.self
   
   /// An initializer.
   public init() { }
@@ -166,8 +166,11 @@ public extension Theme {
     execute()
     current = v
   }
+    
+    static func setFont<T: FontThemeable>(font: T.Type) {
+        self.font = font.Theme.self
+    }
 }
-
 
 /// A memory reference to the isThemingEnabled for Themeable NSObject subclasses.
 private var IsThemingEnabledKey: UInt8 = 0


### PR DESCRIPTION
The idea is to use RawRepresentable to simplify the creations for Fonts using Material. In one project, we have to add 2 more functions and using the defaults methods made us write a lot of code. So, to simplify things, we added to Material the conformation for FontType to RawRepresentable, turning into a enum where cases are strings with the name of Font. There is two options to keep the old code, FontType.caseValue.font or  FontType.caseValue.size(CGFloat), both will return UIFont.