### PR TITLE
Fix Crash in Xcode 11

### DIFF
--- a/Sources/iOS/Navigation/NavigationBar.swift
+++ b/Sources/iOS/Navigation/NavigationBar.swift
@@ -128,7 +128,15 @@ open class NavigationBar: UINavigationBar, Themeable {
     //since we do not want to unsafely access private view directly
     //iterate subviews to set `layoutMargin` to zero
     for v in subviews {
-      v.layoutMargins = .zero
+      if #available(iOS 13.0, *) {
+        let margins = v.layoutMargins
+        var frame = v.frame
+        frame.origin.x = -margins.left
+        frame.size.width += (margins.left + margins.right)
+        v.frame = frame
+      } else {
+        v.layoutMargins = .zero
+      }
     }
     
     if let v = topItem {


### PR DESCRIPTION
Fixes the crash described in Issue #1250, using the fix provided by @mrtsamma [in a comment on the issue](https://github.com/CosmicMind/Material/issues/1250#issuecomment-530363093).

This should be safe to merge even before Xcode 11 is officially released; the `#available`-block will only run in contexts where the fix is required, and other builds should be unaffected.