### PR TITLE
Fix to Swift Package Manager missing argument

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
         .target(
             name: "Material",
             dependencies: ["Motion"],
-            path: "Sources"
+            path: "Sources",
+            exclude: ["Frameworks"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "Material", targets: ["Material"])
     ],
     dependencies: [
-        .package(url: "https://github.com/CosmicMind/Motion.git"),
+        .package(url: "https://github.com/CosmicMind/Motion.git", .upToNextMajor(from: "3.1.0")),
     ],
     targets: [
         .target(

--- a/Sources/iOS/Type/Shape.swift
+++ b/Sources/iOS/Type/Shape.swift
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+import Foundation
+
 @objc(ShapePreset)
 public enum ShapePreset: Int {
   case none


### PR DESCRIPTION
Fixed bug where Motion version was not specified when using Swift Package Manager.