### PR TITLE
Change submodule ( Motion ) path ( Sources/Frameworks -> Frameworks )

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "Sources/Frameworks/Motion"]
-	path = Sources/Frameworks/Motion
+[submodule "Frameworks/Motion"]
+	path = Frameworks/Motion
 	url = https://github.com/CosmicMind/Motion.git

--- a/Material.xcodeproj/project.pbxproj
+++ b/Material.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@
 		9638322C1B88DFD80015F710 = {
 			isa = PBXGroup;
 			children = (
+				9630ACB71F29A26B00B4217D /* Frameworks */,
 				96D88BF41C1328D800B91418 /* Sources */,
 				963832371B88DFD80015F710 /* Products */,
 			);
@@ -760,7 +761,6 @@
 			isa = PBXGroup;
 			children = (
 				96BCB7EC1CB40DE900C806FE /* Font */,
-				9630ACB71F29A26B00B4217D /* Frameworks */,
 				96BCB7571CB40DC500C806FE /* iOS */,
 				96334EF51C8B84660083986B /* Assets.xcassets */,
 				96D88BFC1C1328D800B91418 /* Info.plist */,

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,7 @@ let package = Package(
         .target(
             name: "Material",
             dependencies: ["Motion"],
-            path: "Sources",
-            exclude: ["Frameworks"]
+            path: "Sources"
         )
     ]
 )


### PR DESCRIPTION
Change submodule ( Motion ) path ( Sources/Frameworks -> Frameworks )

**Package.swift - target - exclude does not work as intended**

**Reason**
SPM (Swift Package Manager) does not support submodules, and when I checked it, I confirmed that when I updated the package, the *material and motion conflict*.
Currently CocoaPods, Carthage, and SPM are using [Motion](https://github.com/Cosmic/Motion), so I suggest changing the Sources/Framework/Motion from the SPM management folder (Sources) to external.