### PR TITLE
check for Touch event before closing menu

### DIFF
--- a/Sources/iOS/FABMenu/FABMenu.swift
+++ b/Sources/iOS/FABMenu/FABMenu.swift
@@ -457,7 +457,10 @@ extension FABMenu {
    - Returns: An optional UIView.
    */
   open override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    guard isOpened, isEnabled else {
+    
+    //under Catalyst, the FabMenu is hit with UIHover events.
+    //If we don't check that the event is a touch, the menu is prematurely closed
+    guard isOpened, isEnabled, event?.type == .touches else {
       return super.hitTest(point, with: event)
     }
     


### PR DESCRIPTION
Under catalyst, as you move the mouse around, it hit tests with UIHoverEvent

these currently trigger closing the menu before you're able to move the mouse up to actually click on anything

we could test explicitly for .hover events and ignore them, but they're not available in earlier versions of iOS, so it's easier to just check for .touches events. This also means that shake, remote control events, etc won't close the menu (though I don't know if they trigger a hit test anyway)