### PR TITLE
Add unique @objc name to TextField

### DIFF
--- a/Sources/iOS/Text/TextField.swift
+++ b/Sources/iOS/Text/TextField.swift
@@ -58,6 +58,7 @@ public protocol TextFieldDelegate: UITextFieldDelegate {
   optional func textField(textField: TextField, didClear text: String?)
 }
 
+@objc(MaterialTextField)
 open class TextField: UITextField, Themeable {
   
   /// Minimum TextField text height.


### PR DESCRIPTION
`TextField` is rather a commonly used name and some of our users had a [naming conflict](https://github.com/Adyen/adyen-ios/issues/627).
We are going to fix it from our side, but I believe it is a "nice thing to do" for Material as well.